### PR TITLE
Support of ROS Melodic / Gazebo 9

### DIFF
--- a/crazyflie_gazebo/include/_version.h
+++ b/crazyflie_gazebo/include/_version.h
@@ -1,0 +1,12 @@
+#if !defined(SIMCF_VERSION_H)
+#define SIMCF_VERSION_H
+
+#include <gazebo/gazebo_config.h>
+
+#if GAZEBO_MAJOR_VERSION >= 9
+#define GAZEBO_9 1
+#else
+#define GAZEBO_9 0
+#endif
+
+#endif // SIMCF_VERSION_H

--- a/crazyflie_gazebo/include/gazebo_cfGhost_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_cfGhost_plugin.h
@@ -17,7 +17,7 @@
 #if GAZEBO_9
 #include <ignition/math/Vector3.hh>
 #else
-#include <gazebo/math/Vector3.hh>
+#include <gazebo/math/gzmath.hh>
 #endif
 
 #include <gazebo/msgs/msgs.hh>
@@ -56,7 +56,7 @@ private:
 #if GAZEBO_9
   typedef ignition::math::Pose3d P3;
 #else
-  typedef gazebo::math::Pose3 P3
+  typedef gazebo::math::Pose P3;
 #endif
 
   std::string m_pose_topic;

--- a/crazyflie_gazebo/include/gazebo_cfGhost_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_cfGhost_plugin.h
@@ -1,21 +1,28 @@
- /*
-  * Copyright 2018 Eric Goubault, Cosynus, LIX, France
-  * Copyright 2018 Sylve Putot, Cosynus, LIX, France
-  * Copyright 2018 Franck Djeumou, Cosynus, LIX, France
-  */
+/*
+ * Copyright 2018 Eric Goubault, Cosynus, LIX, France
+ * Copyright 2018 Sylve Putot, Cosynus, LIX, France
+ * Copyright 2018 Franck Djeumou, Cosynus, LIX, France
+ */
 
 #include <iostream>
 #include <sdf/sdf.hh>
 
 #include <boost/bind.hpp>
 
-#include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
+#include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
-#include <gazebo/physics/physics.hh>
+
+#include "_version.h"
+#if GAZEBO_9
+#include <ignition/math/Vector3.hh>
+#else
 #include <gazebo/math/Vector3.hh>
-#include <gazebo/transport/transport.hh>
+#endif
+
 #include <gazebo/msgs/msgs.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/transport.hh>
 
 #include "ros/ros.h"
 
@@ -27,38 +34,45 @@
 
 namespace gazebo {
 
-	static const std::string kDefaultPoseTopic = "/cf1/pos";
+static const std::string kDefaultPoseTopic = "/cf1/pos";
 
-	class GazeboCfGHostPlugin : public ModelPlugin {
-	public:
-		GazeboCfGHostPlugin() :
-			ModelPlugin(),
-			model_{},
-			world_(nullptr),
-			m_pose_topic(kDefaultPoseTopic)
-			{}
+class GazeboCfGHostPlugin : public ModelPlugin
+{
+public:
+  GazeboCfGHostPlugin()
+    : ModelPlugin()
+    , model_{}
+    , world_(nullptr)
+    , m_pose_topic(kDefaultPoseTopic)
+  {}
 
-		~GazeboCfGHostPlugin();
+  ~GazeboCfGHostPlugin();
 
-	protected:
-		void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
-		void OnUpdate(const common::UpdateInfo& /*_info*/);
+protected:
+  void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  void OnUpdate(const common::UpdateInfo& /*_info*/);
 
-	private:
+private:
+#if GAZEBO_9
+  typedef ignition::math::Pose3d P3;
+#else
+  typedef gazebo::math::Pose3 P3
+#endif
 
-		std::string m_pose_topic;
-		ignition::math::Pose3d last_pose;
+  std::string m_pose_topic;
+  P3 last_pose;
 
-		transport::NodePtr node_handle_;
-		transport::PublisherPtr motor_velocity_reference_pub_;
-		ros::Subscriber poseSubscriber;
+  transport::NodePtr node_handle_;
+  transport::PublisherPtr motor_velocity_reference_pub_;
+  ros::Subscriber poseSubscriber;
 
-		physics::ModelPtr model_;
-		physics::WorldPtr world_;
+  physics::ModelPtr model_;
+  physics::WorldPtr world_;
 
-		/// \brief Pointer to the update event connection.
-		event::ConnectionPtr updateConnection_;
+  /// \brief Pointer to the update event connection.
+  event::ConnectionPtr updateConnection_;
 
-		void poseReceivedCallback(const crazyflie_driver::GenericLogData::ConstPtr& pos);
-	};
+  void poseReceivedCallback(
+    const crazyflie_driver::GenericLogData::ConstPtr& pos);
+};
 }

--- a/crazyflie_gazebo/include/gazebo_cfHandler_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_cfHandler_plugin.h
@@ -15,11 +15,18 @@
 #include <boost/bind.hpp>
 #include <Eigen/Eigen>
 
+#include "_version.h"
+#if GAZEBO_9
+#include <ignition/math/Vector3.hh>
+#else
+#include <gazebo/math/Vector3.hh>
+#endif
+
+
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
-#include <gazebo/math/Vector3.hh>
 #include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/msgs.hh>
 

--- a/crazyflie_gazebo/include/gazebo_cfHandler_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_cfHandler_plugin.h
@@ -19,7 +19,7 @@
 #if GAZEBO_9
 #include <ignition/math/Vector3.hh>
 #else
-#include <gazebo/math/Vector3.hh>
+#include <gazebo/math/gzmath.hh>
 #endif
 
 

--- a/crazyflie_gazebo/include/gazebo_magnetometer_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_magnetometer_plugin.h
@@ -49,7 +49,7 @@ public:
   typedef ignition::math::Pose3d P3;
 #else
   typedef math::Vector3 V3;
-  typedef math::Pose3 P3;
+  typedef math::Pose P3;
 #endif
   typedef std::normal_distribution<> NormalDistribution;
   typedef std::uniform_real_distribution<> UniformDistribution;

--- a/crazyflie_gazebo/include/gazebo_magnetometer_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_magnetometer_plugin.h
@@ -19,8 +19,8 @@
 
 #include <random>
 
-#include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
+#include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 
@@ -38,31 +38,44 @@ static constexpr double kDefaultRefMagNorth = 0.000021493;
 static constexpr double kDefaultRefMagEast = 0.000000815;
 static constexpr double kDefaultRefMagDown = 0.000042795;
 
-static constexpr double kDefaultMagDelay = 0; //Why not
+static constexpr double kDefaultMagDelay = 0; // Why not
 
-class GazeboMagnetometerPlugin : public ModelPlugin {
+class GazeboMagnetometerPlugin : public ModelPlugin
+{
 
- public:
+public:
+#if GAZEBO_9
+  typedef ignition::math::Vector3d V3;
+  typedef ignition::math::Pose3d P3;
+#else
+  typedef math::Vector3 V3;
+  typedef math::Pose3 P3;
+#endif
   typedef std::normal_distribution<> NormalDistribution;
   typedef std::uniform_real_distribution<> UniformDistribution;
 
   GazeboMagnetometerPlugin();
   virtual ~GazeboMagnetometerPlugin();
 
- protected:
+protected:
   void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
   void OnUpdate(const common::UpdateInfo&);
 
- private:
-
-  /// \brief    Flag that is set to true once CreatePubsAndSubs() is called, used
-  ///           to prevent CreatePubsAndSubs() from be called on every OnUpdate().
+private:
+  /// \brief    Flag that is set to true once CreatePubsAndSubs() is called,
+  ///           used
+  ///           to prevent CreatePubsAndSubs() from be called on every
+  ///           OnUpdate().
   bool pubs_and_subs_created_;
 
-  /// \brief    Creates all required publishers and subscribers, incl. routing of messages to/from ROS if required.
-  /// \details  Call this once the first time OnUpdate() is called (can't
-  ///           be called from Load() because there is no guarantee GazeboRosInterfacePlugin has
-  ///           has loaded and listening to ConnectGazeboToRosTopic and ConnectRosToGazeboTopic messages).
+  /// \brief    Creates all required publishers and subscribers, incl. routing
+  ///           of messages to/from ROS if required. 
+  ///
+  /// \details  Call this once the first
+  ///           time OnUpdate() is called (can't
+  ///           be called from Load() because there is no guarantee
+  ///           GazeboRosInterfacePlugin has has loaded and listening to
+  ///           ConnectGazeboToRosTopic and ConnectRosToGazeboTopic messages).
   void CreatePubsAndSubs();
 
   std::string namespace_;
@@ -83,7 +96,7 @@ class GazeboMagnetometerPlugin : public ModelPlugin {
   //// \brief    Pointer to the update event connection.
   event::ConnectionPtr updateConnection_;
 
-  math::Vector3 mag_W_;
+  V3 mag_W_;
 
   /// \brief    magnetometer measurement rate
   double mag_delay_;

--- a/crazyflie_gazebo/include/gazebo_odometry_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_odometry_plugin.h
@@ -29,6 +29,8 @@
 #include <stdio.h>
 
 #include <boost/bind.hpp>
+#include <boost/array.hpp>
+
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gazebo.hh>
@@ -42,6 +44,14 @@
 
 #include "Odometry.pb.h"
 
+#include "_version.h"
+#if GAZEBO_9
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Pose3.hh>
+#else
+#include <gazebo/Math/Vector3.hh>
+#include <gazebo/Math/Pose.hh>
+#endif
 
 namespace gazebo {
 
@@ -63,6 +73,14 @@ class GazeboOdometryPlugin : public ModelPlugin {
   typedef std::uniform_real_distribution<> UniformDistribution;
   typedef std::deque<std::pair<int, gz_geometry_msgs::Odometry> > OdometryQueue;
   typedef boost::array<double, 36> CovarianceMatrix;
+
+#if GAZEBO_9
+  typedef ignition::math::Vector3d V3;
+  typedef ignition::math::Pose3d P3;
+#else
+  typedef math::Vector3 V3;
+  typedef math::Pose3 P3;
+#endif
 
   GazeboOdometryPlugin()
       : ModelPlugin(),

--- a/crazyflie_gazebo/include/gazebo_odometry_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_odometry_plugin.h
@@ -49,8 +49,7 @@
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Pose3.hh>
 #else
-#include <gazebo/Math/Vector3.hh>
-#include <gazebo/Math/Pose.hh>
+#include <gazebo/math/gzmath.hh>
 #endif
 
 namespace gazebo {
@@ -79,7 +78,7 @@ class GazeboOdometryPlugin : public ModelPlugin {
   typedef ignition::math::Pose3d P3;
 #else
   typedef math::Vector3 V3;
-  typedef math::Pose3 P3;
+  typedef math::Pose P3;
 #endif
 
   GazeboOdometryPlugin()

--- a/crazyflie_gazebo/include/gazebo_wind_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_wind_plugin.h
@@ -68,9 +68,9 @@ static const ignition::math::Vector3d kDefaultWindGustDirection =
   ignition::math::Vector3d(0, 1, 0);
 #else
 static const math::Vector3 kDefaultWindDirection =
-  migr_math::Vector3(1, 0, 0);
+  math::Vector3(1, 0, 0);
 static const math::Vector3 kDefaultWindGustDirection =
-  migr_math::Vector3(0, 1, 0);
+  math::Vector3(0, 1, 0);
 #endif
 
 static constexpr bool kDefaultUseCustomStaticWindField = false;

--- a/crazyflie_gazebo/include/gazebo_wind_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_wind_plugin.h
@@ -35,7 +35,7 @@
 #if GAZEBO_9
 #include <ignition/math/Vector3.hh>
 #else
-#include <gazebo/Math/Vector3.hh>
+#include <gazebo/math/gzmath.hh>
 #endif
 
 #include "common.h"

--- a/crazyflie_gazebo/include/gazebo_wind_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_wind_plugin.h
@@ -19,23 +19,29 @@
  * limitations under the License.
  */
 
-
 #ifndef ROTORS_GAZEBO_PLUGINS_GAZEBO_WIND_PLUGIN_H
 #define ROTORS_GAZEBO_PLUGINS_GAZEBO_WIND_PLUGIN_H
 
 #include <string>
 
-#include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
+#include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 
-#include <mav_msgs/default_topics.h>  // This comes from the mav_comm repo
+#include <mav_msgs/default_topics.h> // This comes from the mav_comm repo
+
+#include "_version.h"
+#if GAZEBO_9
+#include <ignition/math/Vector3.hh>
+#else
+#include <gazebo/Math/Vector3.hh>
+#endif
 
 #include "common.h"
 
-#include "WindSpeed.pb.h"             // Wind speed message
-#include "WrenchStamped.pb.h"         // Wind force message
+#include "WindSpeed.pb.h"     // Wind speed message
+#include "WrenchStamped.pb.h" // Wind force message
 
 namespace gazebo {
 // Default values
@@ -55,41 +61,55 @@ static constexpr double kDefaultWindGustDuration = 0.0;
 static constexpr double kDefaultWindSpeedMean = 0.0;
 static constexpr double kDefaultWindSpeedVariance = 0.0;
 
-static const math::Vector3 kDefaultWindDirection = math::Vector3(1, 0, 0);
-static const math::Vector3 kDefaultWindGustDirection = math::Vector3(0, 1, 0);
+#if GAZEBO_9
+static const ignition::math::Vector3d kDefaultWindDirection =
+  ignition::math::Vector3d(1, 0, 0);
+static const ignition::math::Vector3d kDefaultWindGustDirection =
+  ignition::math::Vector3d(0, 1, 0);
+#else
+static const migr_math::Vector3 kDefaultWindDirection =
+  migr_math::Vector3(1, 0, 0);
+static const migr_math::Vector3 kDefaultWindGustDirection =
+  migr_math::Vector3(0, 1, 0);
+#endif
 
 static constexpr bool kDefaultUseCustomStaticWindField = false;
 
-
-
 /// \brief    This gazebo plugin simulates wind acting on a model.
-/// \details  This plugin publishes on a Gazebo topic and instructs the ROS interface plugin to
+/// \details  This plugin publishes on a Gazebo topic and instructs the ROS
+/// interface plugin to
 ///           forward the message onto ROS.
-class GazeboWindPlugin : public ModelPlugin {
- public:
+class GazeboWindPlugin : public ModelPlugin
+{
+public:
+#if GAZEBO_9
+  typedef ignition::math::Vector3d V3;
+#else
+  typedef math::Vector3 V3;
+#endif
   GazeboWindPlugin()
-      : ModelPlugin(),
-        namespace_(kDefaultNamespace),
-        wind_force_pub_topic_(mav_msgs::default_topics::EXTERNAL_FORCE),
-        wind_speed_pub_topic_(mav_msgs::default_topics::WIND_SPEED),
-        wind_force_mean_(kDefaultWindForceMean),
-        wind_force_variance_(kDefaultWindForceVariance),
-        wind_gust_force_mean_(kDefaultWindGustForceMean),
-        wind_gust_force_variance_(kDefaultWindGustForceVariance),
-        wind_speed_mean_(kDefaultWindSpeedMean),
-        wind_speed_variance_(kDefaultWindSpeedVariance),
-        wind_direction_(kDefaultWindDirection),
-        wind_gust_direction_(kDefaultWindGustDirection),
-        use_custom_static_wind_field_(kDefaultUseCustomStaticWindField),
-        frame_id_(kDefaultFrameId),
-        link_name_(kDefaultLinkName),
-        node_handle_(nullptr),
-        pubs_and_subs_created_(false) {}
+    : ModelPlugin()
+    , namespace_(kDefaultNamespace)
+    , wind_force_pub_topic_(mav_msgs::default_topics::EXTERNAL_FORCE)
+    , wind_speed_pub_topic_(mav_msgs::default_topics::WIND_SPEED)
+    , wind_force_mean_(kDefaultWindForceMean)
+    , wind_force_variance_(kDefaultWindForceVariance)
+    , wind_gust_force_mean_(kDefaultWindGustForceMean)
+    , wind_gust_force_variance_(kDefaultWindGustForceVariance)
+    , wind_speed_mean_(kDefaultWindSpeedMean)
+    , wind_speed_variance_(kDefaultWindSpeedVariance)
+    , wind_direction_(kDefaultWindDirection)
+    , wind_gust_direction_(kDefaultWindGustDirection)
+    , use_custom_static_wind_field_(kDefaultUseCustomStaticWindField)
+    , frame_id_(kDefaultFrameId)
+    , link_name_(kDefaultLinkName)
+    , node_handle_(nullptr)
+    , pubs_and_subs_created_(false)
+  {}
 
   virtual ~GazeboWindPlugin();
 
- protected:
-
+protected:
   /// \brief Load the plugin.
   /// \param[in] _model Pointer to the model that loaded this plugin.
   /// \param[in] _sdf SDF element that describes the plugin.
@@ -99,16 +119,19 @@ class GazeboWindPlugin : public ModelPlugin {
   /// \param[in] _info Update timing information.
   void OnUpdate(const common::UpdateInfo& /*_info*/);
 
- private:
-
-  /// \brief    Flag that is set to true once CreatePubsAndSubs() is called, used
-  ///           to prevent CreatePubsAndSubs() from be called on every OnUpdate().
+private:
+  /// \brief    Flag that is set to true once CreatePubsAndSubs() is called,
+  /// used
+  ///           to prevent CreatePubsAndSubs() from be called on every
+  ///           OnUpdate().
   bool pubs_and_subs_created_;
 
-  /// \brief    Creates all required publishers and subscribers, incl. routing of messages to/from ROS if required.
-  /// \details  Call this once the first time OnUpdate() is called (can't
-  ///           be called from Load() because there is no guarantee GazeboRosInterfacePlugin has
-  ///           has loaded and listening to ConnectGazeboToRosTopic and ConnectRosToGazeboTopic messages).
+  /// \brief    Creates all required publishers and subscribers, incl. routing
+  /// of messages to/from ROS if required. \details  Call this once the first
+  /// time OnUpdate() is called (can't
+  ///           be called from Load() because there is no guarantee
+  ///           GazeboRosInterfacePlugin has has loaded and listening to
+  ///           ConnectGazeboToRosTopic and ConnectRosToGazeboTopic messages).
   void CreatePubsAndSubs();
 
   /// \brief    Pointer to the update event connection.
@@ -132,9 +155,18 @@ class GazeboWindPlugin : public ModelPlugin {
   double wind_speed_mean_;
   double wind_speed_variance_;
 
-  math::Vector3 xyz_offset_;
-  math::Vector3 wind_direction_;
-  math::Vector3 wind_gust_direction_;
+  V3 xyz_offset_;
+  V3 wind_direction_;
+  V3 wind_gust_direction_;
+// #if GAZEBO_9
+//   ignition::math::Vector3d xyz_offset_;
+//   ignition::math::Vector3d wind_direction_;
+//   ignition::math::Vector3d wind_gust_direction_;
+// #else
+//   math::Vector3 xyz_offset_;
+//   math::Vector3 wind_direction_;
+//   math::Vector3 wind_gust_direction_;
+// #endif
 
   common::Time wind_gust_end_;
   common::Time wind_gust_start_;
@@ -153,43 +185,60 @@ class GazeboWindPlugin : public ModelPlugin {
   std::vector<float> u_;
   std::vector<float> v_;
   std::vector<float> w_;
-  
+
   /// \brief  Reads wind data from a text file and saves it.
   /// \param[in] custom_wind_field_path Path to the wind field from ~/.ros.
   void ReadCustomWindField(std::string& custom_wind_field_path);
-  
-  /// \brief  Functions for trilinear interpolation of wind field at aircraft position.
-  
+
+  /// \brief  Functions for trilinear interpolation of wind field at aircraft
+  /// position.
+
   /// \brief  Linear interpolation
   /// \param[in]  position y-coordinate of the target point.
-  ///             values Pointer to an array of size 2 containing the wind values
+  ///             values Pointer to an array of size 2 containing the wind
+  ///             values
   ///                    of the two points to interpolate from (12 and 13).
-  ///             points Pointer to an array of size 2 containing the y-coordinate 
+  ///             points Pointer to an array of size 2 containing the
+  ///             y-coordinate
   ///                    of the two points to interpolate from.
-  math::Vector3 LinearInterpolation(double position, math::Vector3* values, double* points) const;
-  
+  V3 LinearInterpolation(double position,
+                                    V3* values,
+                                    double* points) const;
+
   /// \brief  Bilinear interpolation
-  /// \param[in]  position Pointer to an array of size 2 containing the x- and 
+  /// \param[in]  position Pointer to an array of size 2 containing the x- and
   ///                      y-coordinates of the target point.
-  ///             values Pointer to an array of size 4 containing the wind values 
-  ///                    of the four points to interpolate from (8, 9, 10 and 11).
-  ///             points Pointer to an array of size 14 containing the z-coordinate
-  ///                    of the eight points to interpolate from, the x-coordinate 
-  ///                    of the four intermediate points (8, 9, 10 and 11), and the 
-  ///                    y-coordinate of the last two intermediate points (12 and 13).
-  math::Vector3 BilinearInterpolation(double* position, math::Vector3* values, double* points) const;
-  
+  ///             values Pointer to an array of size 4 containing the wind
+  ///             values
+  ///                    of the four points to interpolate from (8, 9, 10 and
+  ///                    11).
+  ///             points Pointer to an array of size 14 containing the
+  ///             z-coordinate
+  ///                    of the eight points to interpolate from, the
+  ///                    x-coordinate of the four intermediate points (8, 9, 10
+  ///                    and 11), and the y-coordinate of the last two
+  ///                    intermediate points (12 and 13).
+  V3 BilinearInterpolation(double* position,
+                                      V3* values,
+                                      double* points) const;
+
   /// \brief  Trilinear interpolation
   /// \param[in]  link_position Vector3 containing the x, y and z-coordinates
   ///                           of the target point.
-  ///             values Pointer to an array of size 8 containing the wind values of the 
-  ///                    eight points to interpolate from (0, 1, 2, 3, 4, 5, 6 and 7).
-  ///             points Pointer to an array of size 14 containing the z-coordinate          
-  ///                    of the eight points to interpolate from, the x-coordinate 
-  ///                    of the four intermediate points (8, 9, 10 and 11), and the 
-  ///                    y-coordinate of the last two intermediate points (12 and 13).
-  math::Vector3 TrilinearInterpolation(math::Vector3 link_position, math::Vector3* values, double* points) const;
-  
+  ///             values Pointer to an array of size 8 containing the wind
+  ///             values of the
+  ///                    eight points to interpolate from (0, 1, 2, 3, 4, 5, 6
+  ///                    and 7).
+  ///             points Pointer to an array of size 14 containing the
+  ///             z-coordinate
+  ///                    of the eight points to interpolate from, the
+  ///                    x-coordinate of the four intermediate points (8, 9, 10
+  ///                    and 11), and the y-coordinate of the last two
+  ///                    intermediate points (12 and 13).
+  V3 TrilinearInterpolation(V3 link_position,
+                                       V3* values,
+                                       double* points) const;
+
   gazebo::transport::PublisherPtr wind_force_pub_;
   gazebo::transport::PublisherPtr wind_speed_pub_;
 
@@ -197,12 +246,14 @@ class GazeboWindPlugin : public ModelPlugin {
 
   /// \brief    Gazebo message for sending wind data.
   /// \details  This is defined at the class scope so that it is re-created
-  ///           everytime a wind message needs to be sent, increasing performance.
+  ///           everytime a wind message needs to be sent, increasing
+  ///           performance.
   gz_geometry_msgs::WrenchStamped wrench_stamped_msg_;
 
   /// \brief    Gazebo message for sending wind speed data.
   /// \details  This is defined at the class scope so that it is re-created
-  ///           everytime a wind speed message needs to be sent, increasing performance.
+  ///           everytime a wind speed message needs to be sent, increasing
+  ///           performance.
   gz_mav_msgs::WindSpeed wind_speed_msg_;
 };
 }

--- a/crazyflie_gazebo/include/gazebo_wind_plugin.h
+++ b/crazyflie_gazebo/include/gazebo_wind_plugin.h
@@ -67,9 +67,9 @@ static const ignition::math::Vector3d kDefaultWindDirection =
 static const ignition::math::Vector3d kDefaultWindGustDirection =
   ignition::math::Vector3d(0, 1, 0);
 #else
-static const migr_math::Vector3 kDefaultWindDirection =
+static const math::Vector3 kDefaultWindDirection =
   migr_math::Vector3(1, 0, 0);
-static const migr_math::Vector3 kDefaultWindGustDirection =
+static const math::Vector3 kDefaultWindGustDirection =
   migr_math::Vector3(0, 1, 0);
 #endif
 

--- a/crazyflie_gazebo/src/gazebo_cfGhost_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_cfGhost_plugin.cpp
@@ -48,21 +48,23 @@ GazeboCfGHostPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   model_->SetGravityMode(0);
 
 #if GAZEBO_9
-  last_pose = P3(model_->WorldPose().Pos().X(),
-                 model_->WorldPose().Pos().Y(),
-                 model_->WorldPose().Pos().Z(),
-                 model_->WorldPose().Rot().W(),
-                 model_->WorldPose().Rot().X(),
-                 model_->WorldPose().Rot().Y(),
-                 model_->WorldPose().Rot().Z());
+  // last_pose = P3(model_->WorldPose().Pos().X(),
+  //                model_->WorldPose().Pos().Y(),
+  //                model_->WorldPose().Pos().Z(),
+  //                model_->WorldPose().Rot().W(),
+  //                model_->WorldPose().Rot().X(),
+  //                model_->WorldPose().Rot().Y(),
+  //                model_->WorldPose().Rot().Z());
+  last_pose = P3(model_->WorldPose());
 #else
-  last_pose = P3(model_->GetWorldPose().pos.x,
-                 model_->GetWorldPose().pos.y,
-                 model_->GetWorldPose().pos.z,
-                 model_->GetWorldPose().rot.w,
-                 model_->GetWorldPose().rot.x,
-                 model_->GetWorldPose().rot.y,
-                 model_->GetWorldPose().rot.z);
+  // last_pose = P3(model_->GetWorldPose().pos.x,
+  //                model_->GetWorldPose().pos.y,
+  //                model_->GetWorldPose().pos.z,
+  //                model_->GetWorldPose().rot.w,
+  //                model_->GetWorldPose().rot.x,
+  //                model_->GetWorldPose().rot.y,
+  //                model_->GetWorldPose().rot.z);
+  last_pose = P3(model_->GetWorldPose());
 #endif
 }
 
@@ -92,7 +94,6 @@ GazeboCfGHostPlugin::poseReceivedCallback(
     last_pose = P3(position->values[0],
                    position->values[1],
                    position->values[2],
-                   1.0,
                    0,
                    0,
                    0);

--- a/crazyflie_gazebo/src/gazebo_cfGhost_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_cfGhost_plugin.cpp
@@ -1,7 +1,9 @@
 #include "gazebo_cfGhost_plugin.h"
 
+#include "_version.h"
+
 // #include <tf/transform_datatypes.h>
-#define DEG_2_RAD 3.14159265359/180.0
+#define DEG_2_RAD (3.14159265359 / 180.0)
 
 namespace gazebo {
 
@@ -9,59 +11,97 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboCfGHostPlugin);
 
 GazeboCfGHostPlugin::~GazeboCfGHostPlugin()
 {
-	event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+#if GAZEBO_9
+#else
+  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+#endif
 }
 
-void GazeboCfGHostPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+void
+GazeboCfGHostPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 {
-	gzdbg << __FUNCTION__ << "() called." << std::endl;
+  gzdbg << __FUNCTION__ << "() called." << std::endl;
 
-	model_ = _model;
+  model_ = _model;
 
-	world_ = model_->GetWorld();
+  world_ = model_->GetWorld();
 
-	node_handle_ =  transport::NodePtr(new transport::Node());
-	node_handle_->Init();
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init();
 
-	// Listen to the update event. This event is broadcast every
-	// simulation iteration.
-	updateConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboCfGHostPlugin::OnUpdate, this, _1));
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(
+    boost::bind(&GazeboCfGHostPlugin::OnUpdate, this, _1));
 
-	motor_velocity_reference_pub_ = node_handle_->Advertise<gz_mav_msgs::CommandMotorSpeed>(model_->GetName() + "/gazebo/command/motor_speed", 1);
+  motor_velocity_reference_pub_ =
+    node_handle_->Advertise<gz_mav_msgs::CommandMotorSpeed>(
+      model_->GetName() + "/gazebo/command/motor_speed", 1);
 
-	// Get parameter from launch file
-	getSdfParam<std::string>(_sdf,"poseTopic",m_pose_topic , m_pose_topic);
+  // Get parameter from launch file
+  getSdfParam<std::string>(_sdf, "poseTopic", m_pose_topic, m_pose_topic);
 
-	// Create ROS subscriber and ros handler
-	ros::NodeHandle n;
-	poseSubscriber = n.subscribe(m_pose_topic, 1, &GazeboCfGHostPlugin::poseReceivedCallback, this);
-	model_->SetGravityMode(0);
+  // Create ROS subscriber and ros handler
+  ros::NodeHandle n;
+  poseSubscriber = n.subscribe(
+    m_pose_topic, 1, &GazeboCfGHostPlugin::poseReceivedCallback, this);
+  model_->SetGravityMode(0);
 
-	last_pose = ignition::math::Pose3d(model_->GetWorldPose().pos.x, model_->GetWorldPose().pos.y , model_->GetWorldPose().pos.z,
-		model_->GetWorldPose().rot.w,model_->GetWorldPose().rot.x,model_->GetWorldPose().rot.y,model_->GetWorldPose().rot.z);
+#if GAZEBO_9
+  last_pose = P3(model_->WorldPose().Pos().X(),
+                 model_->WorldPose().Pos().Y(),
+                 model_->WorldPose().Pos().Z(),
+                 model_->WorldPose().Rot().W(),
+                 model_->WorldPose().Rot().X(),
+                 model_->WorldPose().Rot().Y(),
+                 model_->WorldPose().Rot().Z());
+#else
+  last_pose = P3(model_->GetWorldPose().pos.x,
+                 model_->GetWorldPose().pos.y,
+                 model_->GetWorldPose().pos.z,
+                 model_->GetWorldPose().rot.w,
+                 model_->GetWorldPose().rot.x,
+                 model_->GetWorldPose().rot.y,
+                 model_->GetWorldPose().rot.z);
+#endif
 }
 
-void GazeboCfGHostPlugin::OnUpdate(const common::UpdateInfo& /*_info*/)
+void
+GazeboCfGHostPlugin::OnUpdate(const common::UpdateInfo& /*_info*/)
 {
-	model_->SetGravityMode(0);
-	gz_mav_msgs::CommandMotorSpeed m_motor_speed;
-	m_motor_speed.add_motor_speed(1000); // 0
-	m_motor_speed.add_motor_speed(1000); // 1
-	m_motor_speed.add_motor_speed(1000); // 2
-	m_motor_speed.add_motor_speed(1000); // 3
-	motor_velocity_reference_pub_->Publish(m_motor_speed);
-	model_->SetWorldPose(last_pose);
+  model_->SetGravityMode(0);
+  gz_mav_msgs::CommandMotorSpeed m_motor_speed;
+  m_motor_speed.add_motor_speed(1000); // 0
+  m_motor_speed.add_motor_speed(1000); // 1
+  m_motor_speed.add_motor_speed(1000); // 2
+  m_motor_speed.add_motor_speed(1000); // 3
+  motor_velocity_reference_pub_->Publish(m_motor_speed);
+  model_->SetWorldPose(last_pose);
 }
 
-void GazeboCfGHostPlugin::poseReceivedCallback(const crazyflie_driver::GenericLogData::ConstPtr& position)
+void
+GazeboCfGHostPlugin::poseReceivedCallback(
+  const crazyflie_driver::GenericLogData::ConstPtr& position)
 {
 
-	/*last_pose=ignition::math::Pose3d(position->pose.position.x , position->pose.position.y , position->pose.position.z, 
-		position->pose.orientation.w , position->pose.orientation.x , position->pose.orientation.y , position->pose.orientation.z);*/
-	if (position->values.size() == 3)
-		last_pose=ignition::math::Pose3d(position->values[0] , position->values[1] , position->values[2], 1.0, 0,0,0);
-	else if (position->values.size() == 6)
-		last_pose=ignition::math::Pose3d(position->values[0] , position->values[1] , position->values[2], position->values[3] * DEG_2_RAD, position->values[4] * DEG_2_RAD, position->values[5]* DEG_2_RAD);
+  /*last_pose=ignition::math::Pose3d(position->pose.position.x ,
+     position->pose.position.y , position->pose.position.z,
+          position->pose.orientation.w , position->pose.orientation.x ,
+     position->pose.orientation.y , position->pose.orientation.z);*/
+  if (position->values.size() == 3)
+    last_pose = P3(position->values[0],
+                   position->values[1],
+                   position->values[2],
+                   1.0,
+                   0,
+                   0,
+                   0);
+  else if (position->values.size() == 6)
+    last_pose = P3(position->values[0],
+                   position->values[1],
+                   position->values[2],
+                   position->values[3] * DEG_2_RAD,
+                   position->values[4] * DEG_2_RAD,
+                   position->values[5] * DEG_2_RAD);
 }
-
 }

--- a/crazyflie_gazebo/src/gazebo_cfHandler_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_cfHandler_plugin.cpp
@@ -6,7 +6,10 @@ namespace gazebo {
 GZ_REGISTER_MODEL_PLUGIN(GazeboCfHandler);
 
 GazeboCfHandler::~GazeboCfHandler(){
+	#if GAZEBO_9
+#else
 	event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+#endif
 	isPluginOn = false;
 	for(uint8_t i=0 ; i<nbQuads ; i++){
 		socketInit[i] = false;

--- a/crazyflie_gazebo/src/gazebo_magnetometer_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_magnetometer_plugin.cpp
@@ -200,7 +200,7 @@ common::Time current_time;
   #if GAZEBO_9
   P3 T_W_B = link_->WorldPose();
 #else
-  math::Pose3 T_W_B = link_->GetWorldPose();
+  math::Pose T_W_B = link_->GetWorldPose();
 #endif
 
   // Calculate the magnetic field noise.

--- a/crazyflie_gazebo/src/gazebo_magnetometer_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_magnetometer_plugin.cpp
@@ -200,7 +200,7 @@ common::Time current_time;
   #if GAZEBO_9
   P3 T_W_B = link_->WorldPose();
 #else
-  math::Pose T_W_B = link_->GetWorldPose();
+  P3 T_W_B = link_->GetWorldPose();
 #endif
 
   // Calculate the magnetic field noise.

--- a/crazyflie_gazebo/src/gazebo_odometry_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_odometry_plugin.cpp
@@ -30,8 +30,9 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#include "_version.h"
+
 // USER
-#include "common.h"
 #include "ConnectGazeboToRosTopic.pb.h"
 #include "ConnectRosToGazeboTopic.pb.h"
 #include "PoseStamped.pb.h"
@@ -39,15 +40,21 @@
 #include "TransformStamped.pb.h"
 #include "TransformStampedWithFrameIds.pb.h"
 #include "Vector3dStamped.pb.h"
+#include "common.h"
 
 namespace gazebo {
 
-GazeboOdometryPlugin::~GazeboOdometryPlugin() {
+GazeboOdometryPlugin::~GazeboOdometryPlugin()
+{
+#if GAZEBO_9
+#else
   event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+#endif
 }
 
-void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
-                                sdf::ElementPtr _sdf) {
+void
+GazeboOdometryPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
   if (kPrintOnPluginLoad) {
     gzdbg << __FUNCTION__ << "() called." << std::endl;
   }
@@ -89,7 +96,7 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
 
   if (_sdf->HasElement("covarianceImage")) {
     std::string image_name =
-        _sdf->GetElement("covarianceImage")->Get<std::string>();
+      _sdf->GetElement("covarianceImage")->Get<std::string>();
     covariance_image_ = cv::imread(image_name, CV_LOAD_IMAGE_GRAYSCALE);
     if (covariance_image_.data == NULL)
       gzerr << "loading covariance image " << image_name << " failed"
@@ -101,50 +108,63 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
 
   if (_sdf->HasElement("randomEngineSeed")) {
     random_generator_.seed(
-        _sdf->GetElement("randomEngineSeed")->Get<unsigned int>());
+      _sdf->GetElement("randomEngineSeed")->Get<unsigned int>());
   } else {
     random_generator_.seed(
-        std::chrono::system_clock::now().time_since_epoch().count());
+      std::chrono::system_clock::now().time_since_epoch().count());
   }
   getSdfParam<std::string>(_sdf, "poseTopic", pose_pub_topic_, pose_pub_topic_);
-  getSdfParam<std::string>(_sdf, "poseWithCovarianceTopic",
+  getSdfParam<std::string>(_sdf,
+                           "poseWithCovarianceTopic",
                            pose_with_covariance_stamped_pub_topic_,
                            pose_with_covariance_stamped_pub_topic_);
-  getSdfParam<std::string>(_sdf, "positionTopic", position_stamped_pub_topic_,
+  getSdfParam<std::string>(_sdf,
+                           "positionTopic",
+                           position_stamped_pub_topic_,
                            position_stamped_pub_topic_);
-  getSdfParam<std::string>(_sdf, "transformTopic", transform_stamped_pub_topic_,
+  getSdfParam<std::string>(_sdf,
+                           "transformTopic",
+                           transform_stamped_pub_topic_,
                            transform_stamped_pub_topic_);
-  getSdfParam<std::string>(_sdf, "odometryTopic", odometry_pub_topic_,
-                           odometry_pub_topic_);
-  getSdfParam<std::string>(_sdf, "parentFrameId", parent_frame_id_,
-                           parent_frame_id_);
-  getSdfParam<std::string>(_sdf, "childFrameId", child_frame_id_,
-                           child_frame_id_);
-  getSdfParam<SdfVector3>(_sdf, "noiseNormalPosition", noise_normal_position,
+  getSdfParam<std::string>(
+    _sdf, "odometryTopic", odometry_pub_topic_, odometry_pub_topic_);
+  getSdfParam<std::string>(
+    _sdf, "parentFrameId", parent_frame_id_, parent_frame_id_);
+  getSdfParam<std::string>(
+    _sdf, "childFrameId", child_frame_id_, child_frame_id_);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseNormalPosition", noise_normal_position, zeros3);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseNormalQuaternion", noise_normal_quaternion, zeros3);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseNormalLinearVelocity", noise_normal_linear_velocity, zeros3);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseNormalAngularVelocity", noise_normal_angular_velocity, zeros3);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseUniformPosition", noise_uniform_position, zeros3);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseUniformQuaternion", noise_uniform_quaternion, zeros3);
+  getSdfParam<SdfVector3>(
+    _sdf, "noiseUniformLinearVelocity", noise_uniform_linear_velocity, zeros3);
+  getSdfParam<SdfVector3>(_sdf,
+                          "noiseUniformAngularVelocity",
+                          noise_uniform_angular_velocity,
                           zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseNormalQuaternion",
-                          noise_normal_quaternion, zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseNormalLinearVelocity",
-                          noise_normal_linear_velocity, zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseNormalAngularVelocity",
-                          noise_normal_angular_velocity, zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseUniformPosition", noise_uniform_position,
-                          zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseUniformQuaternion",
-                          noise_uniform_quaternion, zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseUniformLinearVelocity",
-                          noise_uniform_linear_velocity, zeros3);
-  getSdfParam<SdfVector3>(_sdf, "noiseUniformAngularVelocity",
-                          noise_uniform_angular_velocity, zeros3);
-  getSdfParam<int>(_sdf, "measurementDelay", measurement_delay_,
-                   measurement_delay_);
-  getSdfParam<int>(_sdf, "measurementDivisor", measurement_divisor_,
-                   measurement_divisor_);
+  getSdfParam<int>(
+    _sdf, "measurementDelay", measurement_delay_, measurement_delay_);
+  getSdfParam<int>(
+    _sdf, "measurementDivisor", measurement_divisor_, measurement_divisor_);
   getSdfParam<double>(_sdf, "unknownDelay", unknown_delay_, unknown_delay_);
-  getSdfParam<double>(_sdf, "covarianceImageScale", covariance_image_scale_,
+  getSdfParam<double>(_sdf,
+                      "covarianceImageScale",
+                      covariance_image_scale_,
                       covariance_image_scale_);
 
+#if GAZEBO_9
+  parent_link_ = world_->EntityByName(parent_frame_id_);
+#else
   parent_link_ = world_->GetEntity(parent_frame_id_);
+#endif
   if (parent_link_ == NULL && parent_frame_id_ != kDefaultParentFrameId) {
     gzthrow("[gazebo_odometry_plugin] Couldn't find specified parent link \""
             << parent_frame_id_ << "\".");
@@ -159,18 +179,18 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
   attitude_n_[2] = NormalDistribution(0, noise_normal_quaternion.Z());
 
   linear_velocity_n_[0] =
-      NormalDistribution(0, noise_normal_linear_velocity.X());
+    NormalDistribution(0, noise_normal_linear_velocity.X());
   linear_velocity_n_[1] =
-      NormalDistribution(0, noise_normal_linear_velocity.Y());
+    NormalDistribution(0, noise_normal_linear_velocity.Y());
   linear_velocity_n_[2] =
-      NormalDistribution(0, noise_normal_linear_velocity.Z());
+    NormalDistribution(0, noise_normal_linear_velocity.Z());
 
   angular_velocity_n_[0] =
-      NormalDistribution(0, noise_normal_angular_velocity.X());
+    NormalDistribution(0, noise_normal_angular_velocity.X());
   angular_velocity_n_[1] =
-      NormalDistribution(0, noise_normal_angular_velocity.Y());
+    NormalDistribution(0, noise_normal_angular_velocity.Y());
   angular_velocity_n_[2] =
-      NormalDistribution(0, noise_normal_angular_velocity.Z());
+    NormalDistribution(0, noise_normal_angular_velocity.Z());
 
   position_u_[0] = UniformDistribution(-noise_uniform_position.X(),
                                        noise_uniform_position.X());
@@ -187,54 +207,56 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
                                        noise_uniform_quaternion.Z());
 
   linear_velocity_u_[0] = UniformDistribution(
-      -noise_uniform_linear_velocity.X(), noise_uniform_linear_velocity.X());
+    -noise_uniform_linear_velocity.X(), noise_uniform_linear_velocity.X());
   linear_velocity_u_[1] = UniformDistribution(
-      -noise_uniform_linear_velocity.Y(), noise_uniform_linear_velocity.Y());
+    -noise_uniform_linear_velocity.Y(), noise_uniform_linear_velocity.Y());
   linear_velocity_u_[2] = UniformDistribution(
-      -noise_uniform_linear_velocity.Z(), noise_uniform_linear_velocity.Z());
+    -noise_uniform_linear_velocity.Z(), noise_uniform_linear_velocity.Z());
 
   angular_velocity_u_[0] = UniformDistribution(
-      -noise_uniform_angular_velocity.X(), noise_uniform_angular_velocity.X());
+    -noise_uniform_angular_velocity.X(), noise_uniform_angular_velocity.X());
   angular_velocity_u_[1] = UniformDistribution(
-      -noise_uniform_angular_velocity.Y(), noise_uniform_angular_velocity.Y());
+    -noise_uniform_angular_velocity.Y(), noise_uniform_angular_velocity.Y());
   angular_velocity_u_[2] = UniformDistribution(
-      -noise_uniform_angular_velocity.Z(), noise_uniform_angular_velocity.Z());
+    -noise_uniform_angular_velocity.Z(), noise_uniform_angular_velocity.Z());
 
   // Fill in covariance. We omit uniform noise here.
-  Eigen::Map<Eigen::Matrix<double, 6, 6> > pose_covariance(
-      pose_covariance_matrix_.data());
+  Eigen::Map<Eigen::Matrix<double, 6, 6>> pose_covariance(
+    pose_covariance_matrix_.data());
   Eigen::Matrix<double, 6, 1> pose_covd;
 
   pose_covd << noise_normal_position.X() * noise_normal_position.X(),
-      noise_normal_position.Y() * noise_normal_position.Y(),
-      noise_normal_position.Z() * noise_normal_position.Z(),
-      noise_normal_quaternion.X() * noise_normal_quaternion.X(),
-      noise_normal_quaternion.Y() * noise_normal_quaternion.Y(),
-      noise_normal_quaternion.Z() * noise_normal_quaternion.Z();
+    noise_normal_position.Y() * noise_normal_position.Y(),
+    noise_normal_position.Z() * noise_normal_position.Z(),
+    noise_normal_quaternion.X() * noise_normal_quaternion.X(),
+    noise_normal_quaternion.Y() * noise_normal_quaternion.Y(),
+    noise_normal_quaternion.Z() * noise_normal_quaternion.Z();
   pose_covariance = pose_covd.asDiagonal();
 
   // Fill in covariance. We omit uniform noise here.
-  Eigen::Map<Eigen::Matrix<double, 6, 6> > twist_covariance(
-      twist_covariance_matrix_.data());
+  Eigen::Map<Eigen::Matrix<double, 6, 6>> twist_covariance(
+    twist_covariance_matrix_.data());
   Eigen::Matrix<double, 6, 1> twist_covd;
 
   twist_covd << noise_normal_linear_velocity.X() *
-                    noise_normal_linear_velocity.X(),
-      noise_normal_linear_velocity.Y() * noise_normal_linear_velocity.Y(),
-      noise_normal_linear_velocity.Z() * noise_normal_linear_velocity.Z(),
-      noise_normal_angular_velocity.X() * noise_normal_angular_velocity.X(),
-      noise_normal_angular_velocity.Y() * noise_normal_angular_velocity.Y(),
-      noise_normal_angular_velocity.Z() * noise_normal_angular_velocity.Z();
+                  noise_normal_linear_velocity.X(),
+    noise_normal_linear_velocity.Y() * noise_normal_linear_velocity.Y(),
+    noise_normal_linear_velocity.Z() * noise_normal_linear_velocity.Z(),
+    noise_normal_angular_velocity.X() * noise_normal_angular_velocity.X(),
+    noise_normal_angular_velocity.Y() * noise_normal_angular_velocity.Y(),
+    noise_normal_angular_velocity.Z() * noise_normal_angular_velocity.Z();
   twist_covariance = twist_covd.asDiagonal();
 
   // Listen to the update event. This event is broadcast every
   // simulation iteration.
   updateConnection_ = event::Events::ConnectWorldUpdateBegin(
-      boost::bind(&GazeboOdometryPlugin::OnUpdate, this, _1));
+    boost::bind(&GazeboOdometryPlugin::OnUpdate, this, _1));
 }
 
 // This gets called by the world update start event.
-void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
+void
+GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info)
+{
   if (kPrintOnUpdates) {
     gzdbg << __FUNCTION__ << "() called." << std::endl;
   }
@@ -246,6 +268,14 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
   // C denotes child frame, P parent frame, and W world frame.
   // Further C_pose_W_P denotes pose of P wrt. W expressed in C.
+#if GAZEBO_9
+  P3 W_pose_W_C = link_->WorldCoGPose();
+  V3 C_linear_velocity_W_C = link_->RelativeLinearVel();
+  V3 C_angular_velocity_W_C = link_->RelativeAngularVel();
+  V3 gazebo_linear_velocity = C_linear_velocity_W_C;
+  V3 gazebo_angular_velocity = C_angular_velocity_W_C;
+  P3 gazebo_pose = W_pose_W_C;
+#else
   math::Pose W_pose_W_C = link_->GetWorldCoGPose();
   math::Vector3 C_linear_velocity_W_C = link_->GetRelativeLinearVel();
   math::Vector3 C_angular_velocity_W_C = link_->GetRelativeAngularVel();
@@ -253,29 +283,51 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
   math::Vector3 gazebo_linear_velocity = C_linear_velocity_W_C;
   math::Vector3 gazebo_angular_velocity = C_angular_velocity_W_C;
   math::Pose gazebo_pose = W_pose_W_C;
+#endif
 
   if (parent_frame_id_ != kDefaultParentFrameId) {
+#if GAZEBO_9
+    P3 W_pose_W_P = parent_link_->WorldPose();
+    V3 P_linear_velocity_W_P = parent_link_->RelativeLinearVel();
+    V3 P_angular_velocity_W_P = parent_link_->RelativeAngularVel();
+    P3 C_pose_P_C_ = W_pose_W_C - W_pose_W_P;
+    V3 C_linear_velocity_P_C;
+#else
     math::Pose W_pose_W_P = parent_link_->GetWorldPose();
     math::Vector3 P_linear_velocity_W_P = parent_link_->GetRelativeLinearVel();
     math::Vector3 P_angular_velocity_W_P =
-        parent_link_->GetRelativeAngularVel();
+      parent_link_->GetRelativeAngularVel();
     math::Pose C_pose_P_C_ = W_pose_W_C - W_pose_W_P;
     math::Vector3 C_linear_velocity_P_C;
-    // \prescript{}{C}{\dot{r}}_{PC} = -R_{CP}
-    //       \cdot \prescript{}{P}{\omega}_{WP} \cross \prescript{}{P}{r}_{PC}
-    //       + \prescript{}{C}{v}_{WC}
-    //                                 - R_{CP} \cdot \prescript{}{P}{v}_{WP}
+#endif
+// \prescript{}{C}{\dot{r}}_{PC} = -R_{CP}
+//       \cdot \prescript{}{P}{\omega}_{WP} \cross \prescript{}{P}{r}_{PC}
+//       + \prescript{}{C}{v}_{WC}
+//                                 - R_{CP} \cdot \prescript{}{P}{v}_{WP}
+#if GAZEBO_9
+    C_linear_velocity_P_C = -C_pose_P_C_.Rot().Inverse() *
+                              P_angular_velocity_W_P.Cross(C_pose_P_C_.Pos()) +
+                            C_linear_velocity_W_C -
+                            C_pose_P_C_.Rot().Inverse() * P_linear_velocity_W_P;
+#else
     C_linear_velocity_P_C =
-        -C_pose_P_C_.rot.GetInverse() *
-            P_angular_velocity_W_P.Cross(C_pose_P_C_.pos) +
-        C_linear_velocity_W_C -
-        C_pose_P_C_.rot.GetInverse() * P_linear_velocity_W_P;
+      -C_pose_P_C_.rot.GetInverse() *
+        P_angular_velocity_W_P.Cross(C_pose_P_C_.pos) +
+      C_linear_velocity_W_C -
+      C_pose_P_C_.rot.GetInverse() * P_linear_velocity_W_P;
+#endif
 
-    // \prescript{}{C}{\omega}_{PC} = \prescript{}{C}{\omega}_{WC}
-    //       - R_{CP} \cdot \prescript{}{P}{\omega}_{WP}
+// \prescript{}{C}{\omega}_{PC} = \prescript{}{C}{\omega}_{WC}
+//       - R_{CP} \cdot \prescript{}{P}{\omega}_{WP}
+#if GAZEBO_9
     gazebo_angular_velocity =
-        C_angular_velocity_W_C -
-        C_pose_P_C_.rot.GetInverse() * P_angular_velocity_W_P;
+      C_angular_velocity_W_C -
+      C_pose_P_C_.Rot().Inverse() * P_angular_velocity_W_P;
+#else
+    gazebo_angular_velocity =
+      C_angular_velocity_W_C -
+      C_pose_P_C_.rot.GetInverse() * P_angular_velocity_W_P;
+#endif
     gazebo_linear_velocity = C_linear_velocity_P_C;
     gazebo_pose = C_pose_P_C_;
   }
@@ -290,12 +342,19 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     // Image is always centered around the origin:
     int width = covariance_image_.cols;
     int height = covariance_image_.rows;
-    int x = static_cast<int>(
-                std::floor(gazebo_pose.pos.x / covariance_image_scale_)) +
-            width / 2;
-    int y = static_cast<int>(
-                std::floor(gazebo_pose.pos.y / covariance_image_scale_)) +
-            height / 2;
+#if GAZEBO_9
+    double gazebo_pos_x = gazebo_pose.Pos().X();
+    double gazebo_pos_y = gazebo_pose.Pos().Y();
+#else
+    double gazebo_pos_x = gazebo_pose.pos.x;
+    double gazebo_pos_y = gazebo_pose.pos.y;
+#endif
+    int x =
+      static_cast<int>(std::floor(gazebo_pos_x / covariance_image_scale_)) +
+      width / 2;
+    int y =
+      static_cast<int>(std::floor(gazebo_pos_y / covariance_image_scale_)) +
+      height / 2;
 
     if (x >= 0 && x < width && y >= 0 && y < height) {
       uint8_t pixel_value = covariance_image_.at<uint8_t>(y, x);
@@ -309,46 +368,85 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
   if (gazebo_sequence_ % measurement_divisor_ == 0) {
     gz_geometry_msgs::Odometry odometry;
-    odometry.mutable_header()->set_frame_id(model_->GetName() + "/"+ parent_frame_id_);
+    odometry.mutable_header()->set_frame_id(model_->GetName() + "/" +
+                                            parent_frame_id_);
+#if GAZEBO_9
     odometry.mutable_header()->mutable_stamp()->set_sec(
-        (world_->GetSimTime()).sec + static_cast<int32_t>(unknown_delay_));
+      (world_->SimTime()).sec + static_cast<int32_t>(unknown_delay_));
     odometry.mutable_header()->mutable_stamp()->set_nsec(
-        (world_->GetSimTime()).nsec + static_cast<int32_t>(unknown_delay_));
+      (world_->SimTime()).nsec + static_cast<int32_t>(unknown_delay_));
     odometry.set_child_frame_id(child_frame_id_);
 
     odometry.mutable_pose()->mutable_pose()->mutable_position()->set_x(
-        gazebo_pose.pos.x);
+      gazebo_pose.Pos().X());
     odometry.mutable_pose()->mutable_pose()->mutable_position()->set_y(
-        gazebo_pose.pos.y);
+      gazebo_pose.Pos().Y());
     odometry.mutable_pose()->mutable_pose()->mutable_position()->set_z(
-        gazebo_pose.pos.z);
+      gazebo_pose.Pos().Z());
 
     odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_x(
-        gazebo_pose.rot.x);
+      gazebo_pose.Rot().X());
     odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_y(
-        gazebo_pose.rot.y);
+      gazebo_pose.Rot().Y());
     odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_z(
-        gazebo_pose.rot.z);
+      gazebo_pose.Rot().Z());
     odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_w(
-        gazebo_pose.rot.w);
+      gazebo_pose.Rot().W());
 
     odometry.mutable_twist()->mutable_twist()->mutable_linear()->set_x(
-        gazebo_linear_velocity.x);
+      gazebo_linear_velocity.X());
     odometry.mutable_twist()->mutable_twist()->mutable_linear()->set_y(
-        gazebo_linear_velocity.y);
+      gazebo_linear_velocity.Y());
     odometry.mutable_twist()->mutable_twist()->mutable_linear()->set_z(
-        gazebo_linear_velocity.z);
+      gazebo_linear_velocity.Z());
 
     odometry.mutable_twist()->mutable_twist()->mutable_angular()->set_x(
-        gazebo_angular_velocity.x);
+      gazebo_angular_velocity.X());
     odometry.mutable_twist()->mutable_twist()->mutable_angular()->set_y(
-        gazebo_angular_velocity.y);
+      gazebo_angular_velocity.Y());
     odometry.mutable_twist()->mutable_twist()->mutable_angular()->set_z(
-        gazebo_angular_velocity.z);
+      gazebo_angular_velocity.Z());
+#else
+    odometry.mutable_header()->mutable_stamp()->set_sec(
+      (world_->GetSimTime()).sec + static_cast<int32_t>(unknown_delay_));
+    odometry.mutable_header()->mutable_stamp()->set_nsec(
+      (world_->GetSimTime()).nsec + static_cast<int32_t>(unknown_delay_));
+    odometry.set_child_frame_id(child_frame_id_);
+
+    odometry.mutable_pose()->mutable_pose()->mutable_position()->set_x(
+      gazebo_pose.pos.x);
+    odometry.mutable_pose()->mutable_pose()->mutable_position()->set_y(
+      gazebo_pose.pos.y);
+    odometry.mutable_pose()->mutable_pose()->mutable_position()->set_z(
+      gazebo_pose.pos.z);
+
+    odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_x(
+      gazebo_pose.rot.x);
+    odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_y(
+      gazebo_pose.rot.y);
+    odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_z(
+      gazebo_pose.rot.z);
+    odometry.mutable_pose()->mutable_pose()->mutable_orientation()->set_w(
+      gazebo_pose.rot.w);
+
+    odometry.mutable_twist()->mutable_twist()->mutable_linear()->set_x(
+      gazebo_linear_velocity.x);
+    odometry.mutable_twist()->mutable_twist()->mutable_linear()->set_y(
+      gazebo_linear_velocity.y);
+    odometry.mutable_twist()->mutable_twist()->mutable_linear()->set_z(
+      gazebo_linear_velocity.z);
+
+    odometry.mutable_twist()->mutable_twist()->mutable_angular()->set_x(
+      gazebo_angular_velocity.x);
+    odometry.mutable_twist()->mutable_twist()->mutable_angular()->set_y(
+      gazebo_angular_velocity.y);
+    odometry.mutable_twist()->mutable_twist()->mutable_angular()->set_z(
+      gazebo_angular_velocity.z);
+#endif
 
     if (publish_odometry)
       odometry_queue_.push_back(
-          std::make_pair(gazebo_sequence_ + measurement_delay_, odometry));
+        std::make_pair(gazebo_sequence_ + measurement_delay_, odometry));
   }
 
   // Is it time to publish the front element?
@@ -362,12 +460,12 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     // Calculate position distortions.
     Eigen::Vector3d pos_n;
     pos_n << position_n_[0](random_generator_) +
-                 position_u_[0](random_generator_),
-        position_n_[1](random_generator_) + position_u_[1](random_generator_),
-        position_n_[2](random_generator_) + position_u_[2](random_generator_);
+               position_u_[0](random_generator_),
+      position_n_[1](random_generator_) + position_u_[1](random_generator_),
+      position_n_[2](random_generator_) + position_u_[2](random_generator_);
 
     gazebo::msgs::Vector3d* p =
-        odometry_msg.mutable_pose()->mutable_pose()->mutable_position();
+      odometry_msg.mutable_pose()->mutable_pose()->mutable_position();
     p->set_x(p->x() + pos_n[0]);
     p->set_y(p->y() + pos_n[1]);
     p->set_z(p->z() + pos_n[2]);
@@ -375,14 +473,14 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     // Calculate attitude distortions.
     Eigen::Vector3d theta;
     theta << attitude_n_[0](random_generator_) +
-                 attitude_u_[0](random_generator_),
-        attitude_n_[1](random_generator_) + attitude_u_[1](random_generator_),
-        attitude_n_[2](random_generator_) + attitude_u_[2](random_generator_);
+               attitude_u_[0](random_generator_),
+      attitude_n_[1](random_generator_) + attitude_u_[1](random_generator_),
+      attitude_n_[2](random_generator_) + attitude_u_[2](random_generator_);
     Eigen::Quaterniond q_n = QuaternionFromSmallAngle(theta);
     q_n.normalize();
 
     gazebo::msgs::Quaternion* q_W_L =
-        odometry_msg.mutable_pose()->mutable_pose()->mutable_orientation();
+      odometry_msg.mutable_pose()->mutable_pose()->mutable_orientation();
 
     Eigen::Quaterniond _q_W_L(q_W_L->w(), q_W_L->x(), q_W_L->y(), q_W_L->z());
     _q_W_L = _q_W_L * q_n;
@@ -394,14 +492,14 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     // Calculate linear velocity distortions.
     Eigen::Vector3d linear_velocity_n;
     linear_velocity_n << linear_velocity_n_[0](random_generator_) +
-                             linear_velocity_u_[0](random_generator_),
-        linear_velocity_n_[1](random_generator_) +
-            linear_velocity_u_[1](random_generator_),
-        linear_velocity_n_[2](random_generator_) +
-            linear_velocity_u_[2](random_generator_);
+                           linear_velocity_u_[0](random_generator_),
+      linear_velocity_n_[1](random_generator_) +
+        linear_velocity_u_[1](random_generator_),
+      linear_velocity_n_[2](random_generator_) +
+        linear_velocity_u_[2](random_generator_);
 
     gazebo::msgs::Vector3d* linear_velocity =
-        odometry_msg.mutable_twist()->mutable_twist()->mutable_linear();
+      odometry_msg.mutable_twist()->mutable_twist()->mutable_linear();
 
     linear_velocity->set_x(linear_velocity->x() + linear_velocity_n[0]);
     linear_velocity->set_y(linear_velocity->y() + linear_velocity_n[1]);
@@ -410,14 +508,14 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     // Calculate angular velocity distortions.
     Eigen::Vector3d angular_velocity_n;
     angular_velocity_n << angular_velocity_n_[0](random_generator_) +
-                              angular_velocity_u_[0](random_generator_),
-        angular_velocity_n_[1](random_generator_) +
-            angular_velocity_u_[1](random_generator_),
-        angular_velocity_n_[2](random_generator_) +
-            angular_velocity_u_[2](random_generator_);
+                            angular_velocity_u_[0](random_generator_),
+      angular_velocity_n_[1](random_generator_) +
+        angular_velocity_u_[1](random_generator_),
+      angular_velocity_n_[2](random_generator_) +
+        angular_velocity_u_[2](random_generator_);
 
     gazebo::msgs::Vector3d* angular_velocity =
-        odometry_msg.mutable_twist()->mutable_twist()->mutable_angular();
+      odometry_msg.mutable_twist()->mutable_twist()->mutable_angular();
 
     angular_velocity->set_x(angular_velocity->x() + angular_velocity_n[0]);
     angular_velocity->set_y(angular_velocity->y() + angular_velocity_n[1]);
@@ -426,13 +524,13 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     odometry_msg.mutable_pose()->mutable_covariance()->Clear();
     for (int i = 0; i < pose_covariance_matrix_.size(); i++) {
       odometry_msg.mutable_pose()->mutable_covariance()->Add(
-          pose_covariance_matrix_[i]);
+        pose_covariance_matrix_[i]);
     }
 
     odometry_msg.mutable_twist()->mutable_covariance()->Clear();
     for (int i = 0; i < twist_covariance_matrix_.size(); i++) {
       odometry_msg.mutable_twist()->mutable_covariance()->Add(
-          twist_covariance_matrix_[i]);
+        twist_covariance_matrix_[i]);
     }
 
     // Publish all the topics, for which the topic name is specified.
@@ -442,22 +540,22 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
     if (pose_with_covariance_stamped_pub_->HasConnections()) {
       gz_geometry_msgs::PoseWithCovarianceStamped
-          pose_with_covariance_stamped_msg;
+        pose_with_covariance_stamped_msg;
 
       pose_with_covariance_stamped_msg.mutable_header()->CopyFrom(
-          odometry_msg.header());
+        odometry_msg.header());
       pose_with_covariance_stamped_msg.mutable_pose_with_covariance()->CopyFrom(
-          odometry_msg.pose());
+        odometry_msg.pose());
 
       pose_with_covariance_stamped_pub_->Publish(
-          pose_with_covariance_stamped_msg);
+        pose_with_covariance_stamped_msg);
     }
 
     if (position_stamped_pub_->HasConnections()) {
       gz_geometry_msgs::Vector3dStamped position_stamped_msg;
       position_stamped_msg.mutable_header()->CopyFrom(odometry_msg.header());
       position_stamped_msg.mutable_position()->CopyFrom(
-          odometry_msg.pose().pose().position());
+        odometry_msg.pose().pose().position());
 
       position_stamped_pub_->Publish(position_stamped_msg);
     }
@@ -467,13 +565,13 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
       transform_stamped_msg.mutable_header()->CopyFrom(odometry_msg.header());
       transform_stamped_msg.mutable_transform()->mutable_translation()->set_x(
-          p->x());
+        p->x());
       transform_stamped_msg.mutable_transform()->mutable_translation()->set_y(
-          p->y());
+        p->y());
       transform_stamped_msg.mutable_transform()->mutable_translation()->set_z(
-          p->z());
+        p->z());
       transform_stamped_msg.mutable_transform()->mutable_rotation()->CopyFrom(
-          *q_W_L);
+        *q_W_L);
 
       transform_stamped_pub_->Publish(transform_stamped_msg);
     }
@@ -488,36 +586,38 @@ void GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info) {
     //==============================================//
 
     gz_geometry_msgs::TransformStampedWithFrameIds
-        transform_stamped_with_frame_ids_msg;
+      transform_stamped_with_frame_ids_msg;
     transform_stamped_with_frame_ids_msg.mutable_header()->CopyFrom(
-        odometry_msg.header());
+      odometry_msg.header());
     transform_stamped_with_frame_ids_msg.mutable_transform()
-        ->mutable_translation()
-        ->set_x(p->x());
+      ->mutable_translation()
+      ->set_x(p->x());
     transform_stamped_with_frame_ids_msg.mutable_transform()
-        ->mutable_translation()
-        ->set_y(p->y());
+      ->mutable_translation()
+      ->set_y(p->y());
     transform_stamped_with_frame_ids_msg.mutable_transform()
-        ->mutable_translation()
-        ->set_z(p->z());
+      ->mutable_translation()
+      ->set_z(p->z());
     transform_stamped_with_frame_ids_msg.mutable_transform()
-        ->mutable_rotation()
-        ->CopyFrom(*q_W_L);
+      ->mutable_rotation()
+      ->CopyFrom(*q_W_L);
     transform_stamped_with_frame_ids_msg.set_parent_frame_id(parent_frame_id_);
     transform_stamped_with_frame_ids_msg.set_child_frame_id(child_frame_id_);
 
     broadcast_transform_pub_->Publish(transform_stamped_with_frame_ids_msg);
 
-  }  // if (gazebo_sequence_ == odometry_queue_.front().first) {
+  } // if (gazebo_sequence_ == odometry_queue_.front().first) {
 
   ++gazebo_sequence_;
 }
 
-void GazeboOdometryPlugin::CreatePubsAndSubs() {
+void
+GazeboOdometryPlugin::CreatePubsAndSubs()
+{
   // Create temporary "ConnectGazeboToRosTopic" publisher and message
   gazebo::transport::PublisherPtr connect_gazebo_to_ros_topic_pub =
-      node_handle_->Advertise<gz_std_msgs::ConnectGazeboToRosTopic>(
-          "~/" + kConnectGazeboToRosSubtopic, 1);
+    node_handle_->Advertise<gz_std_msgs::ConnectGazeboToRosTopic>(
+      "~/" + kConnectGazeboToRosSubtopic, 1);
 
   gz_std_msgs::ConnectGazeboToRosTopic connect_gazebo_to_ros_topic_msg;
 
@@ -526,14 +626,14 @@ void GazeboOdometryPlugin::CreatePubsAndSubs() {
   // ============================================ //
 
   pose_pub_ = node_handle_->Advertise<gazebo::msgs::Pose>(
-      model_->GetName() + "/" + pose_pub_topic_, 1);
+    model_->GetName() + "/" + pose_pub_topic_, 1);
 
   connect_gazebo_to_ros_topic_msg.set_gazebo_topic(model_->GetName() + "/" +
                                                    pose_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_ros_topic(model_->GetName() + "/" +
                                                 pose_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_msgtype(
-      gz_std_msgs::ConnectGazeboToRosTopic::POSE);
+    gz_std_msgs::ConnectGazeboToRosTopic::POSE);
   connect_gazebo_to_ros_topic_pub->Publish(connect_gazebo_to_ros_topic_msg,
                                            true);
 
@@ -542,15 +642,15 @@ void GazeboOdometryPlugin::CreatePubsAndSubs() {
   // ============================================ //
 
   pose_with_covariance_stamped_pub_ =
-      node_handle_->Advertise<gz_geometry_msgs::PoseWithCovarianceStamped>(
-          model_->GetName() + "/" + pose_with_covariance_stamped_pub_topic_, 1);
+    node_handle_->Advertise<gz_geometry_msgs::PoseWithCovarianceStamped>(
+      model_->GetName() + "/" + pose_with_covariance_stamped_pub_topic_, 1);
 
   connect_gazebo_to_ros_topic_msg.set_gazebo_topic(
-      model_->GetName() + "/" + pose_with_covariance_stamped_pub_topic_);
+    model_->GetName() + "/" + pose_with_covariance_stamped_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_ros_topic(
-      model_->GetName() + "/" + pose_with_covariance_stamped_pub_topic_);
+    model_->GetName() + "/" + pose_with_covariance_stamped_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_msgtype(
-      gz_std_msgs::ConnectGazeboToRosTopic::POSE_WITH_COVARIANCE_STAMPED);
+    gz_std_msgs::ConnectGazeboToRosTopic::POSE_WITH_COVARIANCE_STAMPED);
   connect_gazebo_to_ros_topic_pub->Publish(connect_gazebo_to_ros_topic_msg,
                                            true);
 
@@ -559,15 +659,15 @@ void GazeboOdometryPlugin::CreatePubsAndSubs() {
   // ============================================ //
 
   position_stamped_pub_ =
-      node_handle_->Advertise<gz_geometry_msgs::Vector3dStamped>(
-          model_->GetName() + "/" + position_stamped_pub_topic_, 1);
+    node_handle_->Advertise<gz_geometry_msgs::Vector3dStamped>(
+      model_->GetName() + "/" + position_stamped_pub_topic_, 1);
 
   connect_gazebo_to_ros_topic_msg.set_gazebo_topic(model_->GetName() + "/" +
                                                    position_stamped_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_ros_topic(model_->GetName() + "/" +
                                                 position_stamped_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_msgtype(
-      gz_std_msgs::ConnectGazeboToRosTopic::VECTOR_3D_STAMPED);
+    gz_std_msgs::ConnectGazeboToRosTopic::VECTOR_3D_STAMPED);
   connect_gazebo_to_ros_topic_pub->Publish(connect_gazebo_to_ros_topic_msg,
                                            true);
 
@@ -576,14 +676,14 @@ void GazeboOdometryPlugin::CreatePubsAndSubs() {
   // ============================================ //
 
   odometry_pub_ = node_handle_->Advertise<gz_geometry_msgs::Odometry>(
-      model_->GetName() + "/" + odometry_pub_topic_, 1);
+    model_->GetName() + "/" + odometry_pub_topic_, 1);
 
   connect_gazebo_to_ros_topic_msg.set_gazebo_topic(model_->GetName() + "/" +
                                                    odometry_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_ros_topic(model_->GetName() + "/" +
                                                 odometry_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_msgtype(
-      gz_std_msgs::ConnectGazeboToRosTopic::ODOMETRY);
+    gz_std_msgs::ConnectGazeboToRosTopic::ODOMETRY);
   connect_gazebo_to_ros_topic_pub->Publish(connect_gazebo_to_ros_topic_msg,
                                            true);
 
@@ -592,15 +692,15 @@ void GazeboOdometryPlugin::CreatePubsAndSubs() {
   // ============================================ //
 
   transform_stamped_pub_ =
-      node_handle_->Advertise<gz_geometry_msgs::TransformStamped>(
-          model_->GetName() + "/" + transform_stamped_pub_topic_, 1);
+    node_handle_->Advertise<gz_geometry_msgs::TransformStamped>(
+      model_->GetName() + "/" + transform_stamped_pub_topic_, 1);
 
   connect_gazebo_to_ros_topic_msg.set_gazebo_topic(
-      model_->GetName() + "/" + transform_stamped_pub_topic_);
+    model_->GetName() + "/" + transform_stamped_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_ros_topic(model_->GetName() + "/" +
                                                 transform_stamped_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_msgtype(
-      gz_std_msgs::ConnectGazeboToRosTopic::TRANSFORM_STAMPED);
+    gz_std_msgs::ConnectGazeboToRosTopic::TRANSFORM_STAMPED);
   connect_gazebo_to_ros_topic_pub->Publish(connect_gazebo_to_ros_topic_msg,
                                            true);
 
@@ -609,10 +709,10 @@ void GazeboOdometryPlugin::CreatePubsAndSubs() {
   // ============================================ //
 
   broadcast_transform_pub_ =
-      node_handle_->Advertise<gz_geometry_msgs::TransformStampedWithFrameIds>(
-          "~/" + kBroadcastTransformSubtopic, 1);
+    node_handle_->Advertise<gz_geometry_msgs::TransformStampedWithFrameIds>(
+      "~/" + kBroadcastTransformSubtopic, 1);
 }
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboOdometryPlugin);
 
-}  // namespace gazebo
+} // namespace gazebo

--- a/crazyflie_gazebo/src/gazebo_odometry_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_odometry_plugin.cpp
@@ -276,13 +276,13 @@ GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info)
   V3 gazebo_angular_velocity = C_angular_velocity_W_C;
   P3 gazebo_pose = W_pose_W_C;
 #else
-  math::Pose W_pose_W_C = link_->GetWorldCoGPose();
-  math::Vector3 C_linear_velocity_W_C = link_->GetRelativeLinearVel();
-  math::Vector3 C_angular_velocity_W_C = link_->GetRelativeAngularVel();
+  P3 W_pose_W_C = link_->GetWorldCoGPose();
+  V3 C_linear_velocity_W_C = link_->GetRelativeLinearVel();
+  V3 C_angular_velocity_W_C = link_->GetRelativeAngularVel();
 
-  math::Vector3 gazebo_linear_velocity = C_linear_velocity_W_C;
-  math::Vector3 gazebo_angular_velocity = C_angular_velocity_W_C;
-  math::Pose gazebo_pose = W_pose_W_C;
+  V3 gazebo_linear_velocity = C_linear_velocity_W_C;
+  V3 gazebo_angular_velocity = C_angular_velocity_W_C;
+  P3 gazebo_pose = W_pose_W_C;
 #endif
 
   if (parent_frame_id_ != kDefaultParentFrameId) {
@@ -293,12 +293,12 @@ GazeboOdometryPlugin::OnUpdate(const common::UpdateInfo& _info)
     P3 C_pose_P_C_ = W_pose_W_C - W_pose_W_P;
     V3 C_linear_velocity_P_C;
 #else
-    math::Pose W_pose_W_P = parent_link_->GetWorldPose();
-    math::Vector3 P_linear_velocity_W_P = parent_link_->GetRelativeLinearVel();
-    math::Vector3 P_angular_velocity_W_P =
+    P3 W_pose_W_P = parent_link_->GetWorldPose();
+    V3 P_linear_velocity_W_P = parent_link_->GetRelativeLinearVel();
+    V3 P_angular_velocity_W_P =
       parent_link_->GetRelativeAngularVel();
-    math::Pose C_pose_P_C_ = W_pose_W_C - W_pose_W_P;
-    math::Vector3 C_linear_velocity_P_C;
+    P3 C_pose_P_C_ = W_pose_W_C - W_pose_W_P;
+    V3 C_linear_velocity_P_C;
 #endif
 // \prescript{}{C}{\dot{r}}_{PC} = -R_{CP}
 //       \cdot \prescript{}{P}{\omega}_{WP} \cross \prescript{}{P}{r}_{PC}

--- a/crazyflie_gazebo/src/gazebo_ros_interface_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_ros_interface_plugin.cpp
@@ -18,22 +18,32 @@
 #include "gazebo_ros_interface_plugin.h"
 
 // SYSTEM
-#include <stdio.h>
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <stdio.h>
 
 // 3RD PARTY
-#include <std_msgs/Header.h>
 #include <boost/bind.hpp>
+#include <std_msgs/Header.h>
 
+#include "_version.h"
 namespace gazebo {
 
 GazeboRosInterfacePlugin::GazeboRosInterfacePlugin()
-    : WorldPlugin(), gz_node_handle_(0), ros_node_handle_(0) {}
+  : WorldPlugin()
+  , gz_node_handle_(0)
+  , ros_node_handle_(0)
+{}
 
-GazeboRosInterfacePlugin::~GazeboRosInterfacePlugin() {
+GazeboRosInterfacePlugin::~GazeboRosInterfacePlugin()
+{
+
+#if GAZEBO_9
+
+#else
   event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+#endif
 
   // Shutdown and delete ROS node handle
   if (ros_node_handle_) {
@@ -42,8 +52,9 @@ GazeboRosInterfacePlugin::~GazeboRosInterfacePlugin() {
   }
 }
 
-void GazeboRosInterfacePlugin::Load(physics::WorldPtr _world,
-                                    sdf::ElementPtr _sdf) {
+void
+GazeboRosInterfacePlugin::Load(physics::WorldPtr _world, sdf::ElementPtr _sdf)
+{
   if (kPrintOnPluginLoad) {
     gzdbg << __FUNCTION__ << "() called." << std::endl;
   }
@@ -75,34 +86,39 @@ void GazeboRosInterfacePlugin::Load(physics::WorldPtr _world,
   // Listen to the update event. This event is broadcast every
   // simulation iteration.
   this->updateConnection_ = event::Events::ConnectWorldUpdateBegin(
-      boost::bind(&GazeboRosInterfacePlugin::OnUpdate, this, _1));
+    boost::bind(&GazeboRosInterfacePlugin::OnUpdate, this, _1));
 
   // ============================================ //
   // === CONNECT GAZEBO TO ROS MESSAGES SETUP === //
   // ============================================ //
 
   gz_connect_gazebo_to_ros_topic_sub_ = gz_node_handle_->Subscribe(
-      "~/" + kConnectGazeboToRosSubtopic,
-      &GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback, this);
+    "~/" + kConnectGazeboToRosSubtopic,
+    &GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback,
+    this);
 
   // ============================================ //
   // === CONNECT ROS TO GAZEBO MESSAGES SETUP === //
   // ============================================ //
 
   gz_connect_ros_to_gazebo_topic_sub_ = gz_node_handle_->Subscribe(
-      "~/" + kConnectRosToGazeboSubtopic,
-      &GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback, this);
+    "~/" + kConnectRosToGazeboSubtopic,
+    &GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback,
+    this);
 
   // ============================================ //
   // ===== BROADCAST TRANSFORM MESSAGE SETUP ==== //
   // ============================================ //
 
   gz_broadcast_transform_sub_ = gz_node_handle_->Subscribe(
-      "~/" + kBroadcastTransformSubtopic,
-      &GazeboRosInterfacePlugin::GzBroadcastTransformMsgCallback, this);
+    "~/" + kBroadcastTransformSubtopic,
+    &GazeboRosInterfacePlugin::GzBroadcastTransformMsgCallback,
+    this);
 }
 
-void GazeboRosInterfacePlugin::OnUpdate(const common::UpdateInfo& _info) {
+void
+GazeboRosInterfacePlugin::OnUpdate(const common::UpdateInfo& _info)
+{
   // Do nothing
   // This plugins actions are all executed through message callbacks.
 }
@@ -112,15 +128,17 @@ void GazeboRosInterfacePlugin::OnUpdate(const common::UpdateInfo& _info) {
 /// \details
 ///   GazeboMsgT  The type of the message that will be subscribed to the Gazebo
 ///   framework.
-template <typename GazeboMsgT>
-struct ConnectHelperStorage {
+template<typename GazeboMsgT>
+struct ConnectHelperStorage
+{
   /// \brief    Pointer to the ROS interface plugin class.
   GazeboRosInterfacePlugin* ptr;
 
   /// \brief    Function pointer to the subscriber callback with additional
   /// parameters.
   void (GazeboRosInterfacePlugin::*fp)(
-      const boost::shared_ptr<GazeboMsgT const>&, ros::Publisher ros_publisher);
+    const boost::shared_ptr<GazeboMsgT const>&,
+    ros::Publisher ros_publisher);
 
   /// \brief    The ROS publisher that is passed into the modified callback.
   ros::Publisher ros_publisher;
@@ -129,28 +147,34 @@ struct ConnectHelperStorage {
   ///           callback, and hence can only
   ///           have one parameter (note boost::bind() does not work with the
   ///           current Gazebo Subscribe() definitions).
-  void callback(const boost::shared_ptr<GazeboMsgT const>& msg_ptr) {
+  void callback(const boost::shared_ptr<GazeboMsgT const>& msg_ptr)
+  {
     (ptr->*fp)(msg_ptr, ros_publisher);
   }
 };
 
-template <typename GazeboMsgT, typename RosMsgT>
-void GazeboRosInterfacePlugin::ConnectHelper(
-    void (GazeboRosInterfacePlugin::*fp)(
-        const boost::shared_ptr<GazeboMsgT const>&, ros::Publisher),
-    GazeboRosInterfacePlugin* ptr, std::string gazeboNamespace,
-    std::string gazeboTopicName, std::string rosTopicName,
-    transport::NodePtr gz_node_handle) {
+template<typename GazeboMsgT, typename RosMsgT>
+void
+GazeboRosInterfacePlugin::ConnectHelper(
+  void (GazeboRosInterfacePlugin::*fp)(
+    const boost::shared_ptr<GazeboMsgT const>&,
+    ros::Publisher),
+  GazeboRosInterfacePlugin* ptr,
+  std::string gazeboNamespace,
+  std::string gazeboTopicName,
+  std::string rosTopicName,
+  transport::NodePtr gz_node_handle)
+{
   // One map will be created for each Gazebo message type
-  static std::map<std::string, ConnectHelperStorage<GazeboMsgT> > callback_map;
+  static std::map<std::string, ConnectHelperStorage<GazeboMsgT>> callback_map;
 
   // Create ROS publisher
   ros::Publisher ros_publisher =
-      ros_node_handle_->advertise<RosMsgT>(rosTopicName, 1);
+    ros_node_handle_->advertise<RosMsgT>(rosTopicName, 1);
 
   auto callback_entry = callback_map.emplace(
-      gazeboTopicName,
-      ConnectHelperStorage<GazeboMsgT>{ptr, fp, ros_publisher});
+    gazeboTopicName,
+    ConnectHelperStorage<GazeboMsgT>{ ptr, fp, ros_publisher });
 
   // Check if element was already present
   if (!callback_entry.second)
@@ -160,27 +184,30 @@ void GazeboRosInterfacePlugin::ConnectHelper(
 
   // Create subscriber
   gazebo::transport::SubscriberPtr subscriberPtr;
-  subscriberPtr = gz_node_handle->Subscribe(
-      gazeboTopicName, &ConnectHelperStorage<GazeboMsgT>::callback,
-      &callback_entry.first->second);
+  subscriberPtr =
+    gz_node_handle->Subscribe(gazeboTopicName,
+                              &ConnectHelperStorage<GazeboMsgT>::callback,
+                              &callback_entry.first->second);
 
   // Save a reference to the subscriber pointer so subscriber
   // won't be deleted.
   subscriberPtrs_.push_back(subscriberPtr);
 }
 
-void GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback(
-    GzConnectGazeboToRosTopicMsgPtr& gz_connect_gazebo_to_ros_topic_msg) {
+void
+GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback(
+  GzConnectGazeboToRosTopicMsgPtr& gz_connect_gazebo_to_ros_topic_msg)
+{
   if (kPrintOnMsgCallback) {
     gzdbg << __FUNCTION__ << "() called." << std::endl;
   }
 
   const std::string gazeboNamespace =
-      "";  // gz_connect_gazebo_to_ros_topic_msg->gazebo_namespace();
+    ""; // gz_connect_gazebo_to_ros_topic_msg->gazebo_namespace();
   const std::string gazeboTopicName =
-      gz_connect_gazebo_to_ros_topic_msg->gazebo_topic();
+    gz_connect_gazebo_to_ros_topic_msg->gazebo_topic();
   const std::string rosTopicName =
-      gz_connect_gazebo_to_ros_topic_msg->ros_topic();
+    gz_connect_gazebo_to_ros_topic_msg->ros_topic();
 
   gzdbg << "Connecting Gazebo topic \"" << gazeboTopicName
         << "\" to ROS topic \"" << rosTopicName << "\"." << std::endl;
@@ -188,85 +215,143 @@ void GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback(
   switch (gz_connect_gazebo_to_ros_topic_msg->msgtype()) {
     case gz_std_msgs::ConnectGazeboToRosTopic::ACTUATORS:
       ConnectHelper<gz_sensor_msgs::Actuators, mav_msgs::Actuators>(
-          &GazeboRosInterfacePlugin::GzActuatorsMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzActuatorsMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::FLOAT_32:
       ConnectHelper<gz_std_msgs::Float32, std_msgs::Float32>(
-          &GazeboRosInterfacePlugin::GzFloat32MsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzFloat32MsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::FLUID_PRESSURE:
       ConnectHelper<gz_sensor_msgs::FluidPressure, sensor_msgs::FluidPressure>(
-          &GazeboRosInterfacePlugin::GzFluidPressureMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzFluidPressureMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::IMU:
       ConnectHelper<gz_sensor_msgs::Imu, sensor_msgs::Imu>(
-          &GazeboRosInterfacePlugin::GzImuMsgCallback, this, gazeboNamespace,
-          gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzImuMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::JOINT_STATE:
       ConnectHelper<gz_sensor_msgs::JointState, sensor_msgs::JointState>(
-          &GazeboRosInterfacePlugin::GzJointStateMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzJointStateMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::MAGNETIC_FIELD:
       ConnectHelper<gz_sensor_msgs::MagneticField, sensor_msgs::MagneticField>(
-          &GazeboRosInterfacePlugin::GzMagneticFieldMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzMagneticFieldMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::NAV_SAT_FIX:
       ConnectHelper<gz_sensor_msgs::NavSatFix, sensor_msgs::NavSatFix>(
-          &GazeboRosInterfacePlugin::GzNavSatFixCallback, this, gazeboNamespace,
-          gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzNavSatFixCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::POSE:
       ConnectHelper<gazebo::msgs::Pose, geometry_msgs::Pose>(
-          &GazeboRosInterfacePlugin::GzPoseMsgCallback, this, gazeboNamespace,
-          gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzPoseMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::POSE_WITH_COVARIANCE_STAMPED:
       ConnectHelper<gz_geometry_msgs::PoseWithCovarianceStamped,
                     geometry_msgs::PoseWithCovarianceStamped>(
-          &GazeboRosInterfacePlugin::GzPoseWithCovarianceStampedMsgCallback,
-          this, gazeboNamespace, gazeboTopicName, rosTopicName,
-          gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzPoseWithCovarianceStampedMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::ODOMETRY:
       ConnectHelper<gz_geometry_msgs::Odometry, nav_msgs::Odometry>(
-          &GazeboRosInterfacePlugin::GzOdometryMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzOdometryMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::TRANSFORM_STAMPED:
       ConnectHelper<gz_geometry_msgs::TransformStamped,
                     geometry_msgs::TransformStamped>(
-          &GazeboRosInterfacePlugin::GzTransformStampedMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzTransformStampedMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::TWIST_STAMPED:
       ConnectHelper<gz_geometry_msgs::TwistStamped,
                     geometry_msgs::TwistStamped>(
-          &GazeboRosInterfacePlugin::GzTwistStampedMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzTwistStampedMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::VECTOR_3D_STAMPED:
       ConnectHelper<gz_geometry_msgs::Vector3dStamped,
                     geometry_msgs::PointStamped>(
-          &GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::WIND_SPEED:
-      ConnectHelper<gz_mav_msgs::WindSpeed,
-                    crazyflie_gazebo::WindSpeed>(
-          &GazeboRosInterfacePlugin::GzWindSpeedMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+      ConnectHelper<gz_mav_msgs::WindSpeed, crazyflie_gazebo::WindSpeed>(
+        &GazeboRosInterfacePlugin::GzWindSpeedMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     case gz_std_msgs::ConnectGazeboToRosTopic::WRENCH_STAMPED:
       ConnectHelper<gz_geometry_msgs::WrenchStamped,
                     geometry_msgs::WrenchStamped>(
-          &GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback, this,
-          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+        &GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback,
+        this,
+        gazeboNamespace,
+        gazeboTopicName,
+        rosTopicName,
+        gz_node_handle_);
       break;
     default:
       gzthrow("ConnectGazeboToRosTopic message type with enum val = "
@@ -277,8 +362,10 @@ void GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback(
   gzdbg << __FUNCTION__ << "() finished." << std::endl;
 }
 
-void GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
-    GzConnectRosToGazeboTopicMsgPtr& gz_connect_ros_to_gazebo_topic_msg) {
+void
+GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
+  GzConnectRosToGazeboTopicMsgPtr& gz_connect_ros_to_gazebo_topic_msg)
+{
   if (kPrintOnMsgCallback) {
     gzdbg << __FUNCTION__ << "() called." << std::endl;
   }
@@ -288,15 +375,18 @@ void GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
   switch (gz_connect_ros_to_gazebo_topic_msg->msgtype()) {
     case gz_std_msgs::ConnectRosToGazeboTopic::ACTUATORS: {
       gazebo::transport::PublisherPtr gz_publisher_ptr =
-          gz_node_handle_->Advertise<gz_sensor_msgs::Actuators>(
-              gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
+        gz_node_handle_->Advertise<gz_sensor_msgs::Actuators>(
+          gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
 
       // Create ROS subscriber.
       ros::Subscriber ros_subscriber =
-          ros_node_handle_->subscribe<mav_msgs::Actuators>(
-              gz_connect_ros_to_gazebo_topic_msg->ros_topic(), 1,
-              boost::bind(&GazeboRosInterfacePlugin::RosActuatorsMsgCallback,
-                          this, _1, gz_publisher_ptr));
+        ros_node_handle_->subscribe<mav_msgs::Actuators>(
+          gz_connect_ros_to_gazebo_topic_msg->ros_topic(),
+          1,
+          boost::bind(&GazeboRosInterfacePlugin::RosActuatorsMsgCallback,
+                      this,
+                      _1,
+                      gz_publisher_ptr));
 
       // Save reference to the ROS subscriber so callback will continue to be
       // called.
@@ -306,16 +396,19 @@ void GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
     }
     case gz_std_msgs::ConnectRosToGazeboTopic::COMMAND_MOTOR_SPEED: {
       gazebo::transport::PublisherPtr gz_publisher_ptr =
-          gz_node_handle_->Advertise<gz_mav_msgs::CommandMotorSpeed>(
-              gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
+        gz_node_handle_->Advertise<gz_mav_msgs::CommandMotorSpeed>(
+          gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
 
       // Create ROS subscriber.
       ros::Subscriber ros_subscriber =
-          ros_node_handle_->subscribe<mav_msgs::Actuators>(
-              gz_connect_ros_to_gazebo_topic_msg->ros_topic(), 1,
-              boost::bind(
-                  &GazeboRosInterfacePlugin::RosCommandMotorSpeedMsgCallback,
-                  this, _1, gz_publisher_ptr));
+        ros_node_handle_->subscribe<mav_msgs::Actuators>(
+          gz_connect_ros_to_gazebo_topic_msg->ros_topic(),
+          1,
+          boost::bind(
+            &GazeboRosInterfacePlugin::RosCommandMotorSpeedMsgCallback,
+            this,
+            _1,
+            gz_publisher_ptr));
 
       // Save reference to the ROS subscriber so callback will continue to be
       // called.
@@ -325,17 +418,19 @@ void GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
     }
     case gz_std_msgs::ConnectRosToGazeboTopic::ROLL_PITCH_YAWRATE_THRUST: {
       gazebo::transport::PublisherPtr gz_publisher_ptr =
-          gz_node_handle_->Advertise<gz_mav_msgs::RollPitchYawrateThrust>(
-              gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
+        gz_node_handle_->Advertise<gz_mav_msgs::RollPitchYawrateThrust>(
+          gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
 
       // Create ROS subscriber.
       ros::Subscriber ros_subscriber =
-          ros_node_handle_->subscribe<mav_msgs::RollPitchYawrateThrust>(
-              gz_connect_ros_to_gazebo_topic_msg->ros_topic(), 1,
-              boost::bind(
-                  &GazeboRosInterfacePlugin::
-                      RosRollPitchYawrateThrustMsgCallback,
-                  this, _1, gz_publisher_ptr));
+        ros_node_handle_->subscribe<mav_msgs::RollPitchYawrateThrust>(
+          gz_connect_ros_to_gazebo_topic_msg->ros_topic(),
+          1,
+          boost::bind(
+            &GazeboRosInterfacePlugin::RosRollPitchYawrateThrustMsgCallback,
+            this,
+            _1,
+            gz_publisher_ptr));
 
       // Save reference to the ROS subscriber so callback will continue to be
       // called.
@@ -345,15 +440,18 @@ void GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
     }
     case gz_std_msgs::ConnectRosToGazeboTopic::WIND_SPEED: {
       gazebo::transport::PublisherPtr gz_publisher_ptr =
-          gz_node_handle_->Advertise<gz_mav_msgs::WindSpeed>(
-              gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
+        gz_node_handle_->Advertise<gz_mav_msgs::WindSpeed>(
+          gz_connect_ros_to_gazebo_topic_msg->gazebo_topic(), 1);
 
       // Create ROS subscriber.
       ros::Subscriber ros_subscriber =
-          ros_node_handle_->subscribe<crazyflie_gazebo::WindSpeed>(
-              gz_connect_ros_to_gazebo_topic_msg->ros_topic(), 1,
-              boost::bind(&GazeboRosInterfacePlugin::RosWindSpeedMsgCallback,
-                          this, _1, gz_publisher_ptr));
+        ros_node_handle_->subscribe<crazyflie_gazebo::WindSpeed>(
+          gz_connect_ros_to_gazebo_topic_msg->ros_topic(),
+          1,
+          boost::bind(&GazeboRosInterfacePlugin::RosWindSpeedMsgCallback,
+                      this,
+                      _1,
+                      gz_publisher_ptr));
 
       // Save reference to the ROS subscriber so callback will continue to be
       // called.
@@ -373,17 +471,21 @@ void GazeboRosInterfacePlugin::GzConnectRosToGazeboTopicMsgCallback(
 //==================== HELPER METHODS FOR MSG CONVERSION ====================//
 //===========================================================================//
 
-void GazeboRosInterfacePlugin::ConvertHeaderGzToRos(
-    const gz_std_msgs::Header& gz_header,
-    std_msgs::Header_<std::allocator<void> >* ros_header) {
+void
+GazeboRosInterfacePlugin::ConvertHeaderGzToRos(
+  const gz_std_msgs::Header& gz_header,
+  std_msgs::Header_<std::allocator<void>>* ros_header)
+{
   ros_header->stamp.sec = gz_header.stamp().sec();
   ros_header->stamp.nsec = gz_header.stamp().nsec();
   ros_header->frame_id = gz_header.frame_id();
 }
 
-void GazeboRosInterfacePlugin::ConvertHeaderRosToGz(
-    const std_msgs::Header_<std::allocator<void> >& ros_header,
-    gz_std_msgs::Header* gz_header) {
+void
+GazeboRosInterfacePlugin::ConvertHeaderRosToGz(
+  const std_msgs::Header_<std::allocator<void>>& ros_header,
+  gz_std_msgs::Header* gz_header)
+{
   gz_header->mutable_stamp()->set_sec(ros_header.stamp.sec);
   gz_header->mutable_stamp()->set_nsec(ros_header.stamp.nsec);
   gz_header->set_frame_id(ros_header.frame_id);
@@ -393,26 +495,31 @@ void GazeboRosInterfacePlugin::ConvertHeaderRosToGz(
 //================ GAZEBO -> ROS MSG CALLBACKS/CONVERTERS ===================//
 //===========================================================================//
 
-void GazeboRosInterfacePlugin::GzActuatorsMsgCallback(
-    GzActuatorsMsgPtr& gz_actuators_msg, ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzActuatorsMsgCallback(
+  GzActuatorsMsgPtr& gz_actuators_msg,
+  ros::Publisher ros_publisher)
+{
   // We need to convert the Acutuators message from a Gazebo message to a
   // ROS message and then publish it to the ROS framework
 
   ConvertHeaderGzToRos(gz_actuators_msg->header(), &ros_actuators_msg_.header);
 
   ros_actuators_msg_.angular_velocities.resize(
-      gz_actuators_msg->angular_velocities_size());
+    gz_actuators_msg->angular_velocities_size());
   for (int i = 0; i < gz_actuators_msg->angular_velocities_size(); i++) {
     ros_actuators_msg_.angular_velocities[i] =
-        gz_actuators_msg->angular_velocities(i);
+      gz_actuators_msg->angular_velocities(i);
   }
 
   // Publish to ROS.
   ros_publisher.publish(ros_actuators_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzFloat32MsgCallback(
-    GzFloat32MsgPtr& gz_float_32_msg, ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzFloat32MsgCallback(GzFloat32MsgPtr& gz_float_32_msg,
+                                               ros::Publisher ros_publisher)
+{
   // Convert Gazebo message to ROS message
   ros_float_32_msg_.data = gz_float_32_msg->data();
 
@@ -420,9 +527,11 @@ void GazeboRosInterfacePlugin::GzFloat32MsgCallback(
   ros_publisher.publish(ros_float_32_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzFluidPressureMsgCallback(
-    GzFluidPressureMsgPtr &gz_fluid_pressure_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzFluidPressureMsgCallback(
+  GzFluidPressureMsgPtr& gz_fluid_pressure_msg,
+  ros::Publisher ros_publisher)
+{
   // We need to convert from a Gazebo message to a ROS message,
   // and then forward the FluidPressure message onto ROS.
 
@@ -430,7 +539,7 @@ void GazeboRosInterfacePlugin::GzFluidPressureMsgCallback(
                        &ros_fluid_pressure_msg_.header);
 
   ros_fluid_pressure_msg_.fluid_pressure =
-      gz_fluid_pressure_msg->fluid_pressure();
+    gz_fluid_pressure_msg->fluid_pressure();
 
   ros_fluid_pressure_msg_.variance = gz_fluid_pressure_msg->variance();
 
@@ -438,8 +547,10 @@ void GazeboRosInterfacePlugin::GzFluidPressureMsgCallback(
   ros_publisher.publish(ros_fluid_pressure_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzImuMsgCallback(GzImuPtr& gz_imu_msg,
-                                                ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzImuMsgCallback(GzImuPtr& gz_imu_msg,
+                                           ros::Publisher ros_publisher)
+{
   // We need to convert from a Gazebo message to a ROS message,
   // and then forward the IMU message onto ROS
 
@@ -456,11 +567,11 @@ void GazeboRosInterfacePlugin::GzImuMsgCallback(GzImuPtr& gz_imu_msg,
             "The Gazebo IMU message does not have 9 orientation covariance "
             "elements.");
   GZ_ASSERT(
-      ros_imu_msg_.orientation_covariance.size() == 9,
-      "The ROS IMU message does not have 9 orientation covariance elements.");
+    ros_imu_msg_.orientation_covariance.size() == 9,
+    "The ROS IMU message does not have 9 orientation covariance elements.");
   for (int i = 0; i < gz_imu_msg->orientation_covariance_size(); i++) {
     ros_imu_msg_.orientation_covariance[i] =
-        gz_imu_msg->orientation_covariance(i);
+      gz_imu_msg->orientation_covariance(i);
   }
 
   ros_imu_msg_.angular_velocity.x = gz_imu_msg->angular_velocity().x();
@@ -475,7 +586,7 @@ void GazeboRosInterfacePlugin::GzImuMsgCallback(GzImuPtr& gz_imu_msg,
             "elements.");
   for (int i = 0; i < gz_imu_msg->angular_velocity_covariance_size(); i++) {
     ros_imu_msg_.angular_velocity_covariance[i] =
-        gz_imu_msg->angular_velocity_covariance(i);
+      gz_imu_msg->angular_velocity_covariance(i);
   }
 
   ros_imu_msg_.linear_acceleration.x = gz_imu_msg->linear_acceleration().x();
@@ -490,15 +601,18 @@ void GazeboRosInterfacePlugin::GzImuMsgCallback(GzImuPtr& gz_imu_msg,
             "covariance elements.");
   for (int i = 0; i < gz_imu_msg->linear_acceleration_covariance_size(); i++) {
     ros_imu_msg_.linear_acceleration_covariance[i] =
-        gz_imu_msg->linear_acceleration_covariance(i);
+      gz_imu_msg->linear_acceleration_covariance(i);
   }
 
   // Publish to ROS.
   ros_publisher.publish(ros_imu_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzJointStateMsgCallback(
-    GzJointStateMsgPtr& gz_joint_state_msg, ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzJointStateMsgCallback(
+  GzJointStateMsgPtr& gz_joint_state_msg,
+  ros::Publisher ros_publisher)
+{
   ConvertHeaderGzToRos(gz_joint_state_msg->header(),
                        &ros_joint_state_msg_.header);
 
@@ -516,9 +630,11 @@ void GazeboRosInterfacePlugin::GzJointStateMsgCallback(
   ros_publisher.publish(ros_joint_state_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzMagneticFieldMsgCallback(
-    GzMagneticFieldMsgPtr& gz_magnetic_field_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzMagneticFieldMsgCallback(
+  GzMagneticFieldMsgPtr& gz_magnetic_field_msg,
+  ros::Publisher ros_publisher)
+{
   // We need to convert from a Gazebo message to a ROS message,
   // and then forward the MagneticField message onto ROS
 
@@ -526,11 +642,11 @@ void GazeboRosInterfacePlugin::GzMagneticFieldMsgCallback(
                        &ros_magnetic_field_msg_.header);
 
   ros_magnetic_field_msg_.magnetic_field.x =
-      gz_magnetic_field_msg->magnetic_field().x();
+    gz_magnetic_field_msg->magnetic_field().x();
   ros_magnetic_field_msg_.magnetic_field.y =
-      gz_magnetic_field_msg->magnetic_field().y();
+    gz_magnetic_field_msg->magnetic_field().y();
   ros_magnetic_field_msg_.magnetic_field.z =
-      gz_magnetic_field_msg->magnetic_field().z();
+    gz_magnetic_field_msg->magnetic_field().z();
 
   // Position covariance should have 9 elements, and both the Gazebo and ROS
   // arrays should be the same size!
@@ -543,15 +659,18 @@ void GazeboRosInterfacePlugin::GzMagneticFieldMsgCallback(
   for (int i = 0; i < gz_magnetic_field_msg->magnetic_field_covariance_size();
        i++) {
     ros_magnetic_field_msg_.magnetic_field_covariance[i] =
-        gz_magnetic_field_msg->magnetic_field_covariance(i);
+      gz_magnetic_field_msg->magnetic_field_covariance(i);
   }
 
   // Publish to ROS.
   ros_publisher.publish(ros_magnetic_field_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzNavSatFixCallback(
-    GzNavSatFixPtr& gz_nav_sat_fix_msg, ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzNavSatFixCallback(
+  GzNavSatFixPtr& gz_nav_sat_fix_msg,
+  ros::Publisher ros_publisher)
+{
   // We need to convert from a Gazebo message to a ROS message, and then forward
   // the NavSatFix message to ROS.
 
@@ -561,47 +680,47 @@ void GazeboRosInterfacePlugin::GzNavSatFixCallback(
   switch (gz_nav_sat_fix_msg->service()) {
     case gz_sensor_msgs::NavSatFix::SERVICE_GPS:
       ros_nav_sat_fix_msg_.status.service =
-          sensor_msgs::NavSatStatus::SERVICE_GPS;
+        sensor_msgs::NavSatStatus::SERVICE_GPS;
       break;
     case gz_sensor_msgs::NavSatFix::SERVICE_GLONASS:
       ros_nav_sat_fix_msg_.status.service =
-          sensor_msgs::NavSatStatus::SERVICE_GLONASS;
+        sensor_msgs::NavSatStatus::SERVICE_GLONASS;
       break;
     case gz_sensor_msgs::NavSatFix::SERVICE_COMPASS:
       ros_nav_sat_fix_msg_.status.service =
-          sensor_msgs::NavSatStatus::SERVICE_COMPASS;
+        sensor_msgs::NavSatStatus::SERVICE_COMPASS;
       break;
     case gz_sensor_msgs::NavSatFix::SERVICE_GALILEO:
       ros_nav_sat_fix_msg_.status.service =
-          sensor_msgs::NavSatStatus::SERVICE_GALILEO;
+        sensor_msgs::NavSatStatus::SERVICE_GALILEO;
       break;
     default:
       gzthrow(
-          "Specific value of enum type gz_sensor_msgs::NavSatFix::Service is "
-          "not yet supported.");
+        "Specific value of enum type gz_sensor_msgs::NavSatFix::Service is "
+        "not yet supported.");
   }
 
   switch (gz_nav_sat_fix_msg->status()) {
     case gz_sensor_msgs::NavSatFix::STATUS_NO_FIX:
       ros_nav_sat_fix_msg_.status.status =
-          sensor_msgs::NavSatStatus::STATUS_NO_FIX;
+        sensor_msgs::NavSatStatus::STATUS_NO_FIX;
       break;
     case gz_sensor_msgs::NavSatFix::STATUS_FIX:
       ros_nav_sat_fix_msg_.status.status =
-          sensor_msgs::NavSatStatus::STATUS_FIX;
+        sensor_msgs::NavSatStatus::STATUS_FIX;
       break;
     case gz_sensor_msgs::NavSatFix::STATUS_SBAS_FIX:
       ros_nav_sat_fix_msg_.status.status =
-          sensor_msgs::NavSatStatus::STATUS_SBAS_FIX;
+        sensor_msgs::NavSatStatus::STATUS_SBAS_FIX;
       break;
     case gz_sensor_msgs::NavSatFix::STATUS_GBAS_FIX:
       ros_nav_sat_fix_msg_.status.status =
-          sensor_msgs::NavSatStatus::STATUS_GBAS_FIX;
+        sensor_msgs::NavSatStatus::STATUS_GBAS_FIX;
       break;
     default:
       gzthrow(
-          "Specific value of enum type gz_sensor_msgs::NavSatFix::Status is "
-          "not yet supported.");
+        "Specific value of enum type gz_sensor_msgs::NavSatFix::Status is "
+        "not yet supported.");
   }
 
   ros_nav_sat_fix_msg_.latitude = gz_nav_sat_fix_msg->latitude();
@@ -611,25 +730,24 @@ void GazeboRosInterfacePlugin::GzNavSatFixCallback(
   switch (gz_nav_sat_fix_msg->position_covariance_type()) {
     case gz_sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN:
       ros_nav_sat_fix_msg_.position_covariance_type =
-          sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
+        sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
       break;
     case gz_sensor_msgs::NavSatFix::COVARIANCE_TYPE_APPROXIMATED:
       ros_nav_sat_fix_msg_.position_covariance_type =
-          sensor_msgs::NavSatFix::COVARIANCE_TYPE_APPROXIMATED;
+        sensor_msgs::NavSatFix::COVARIANCE_TYPE_APPROXIMATED;
       break;
     case gz_sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN:
       ros_nav_sat_fix_msg_.position_covariance_type =
-          sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+        sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
       break;
     case gz_sensor_msgs::NavSatFix::COVARIANCE_TYPE_KNOWN:
       ros_nav_sat_fix_msg_.position_covariance_type =
-          sensor_msgs::NavSatFix::COVARIANCE_TYPE_KNOWN;
+        sensor_msgs::NavSatFix::COVARIANCE_TYPE_KNOWN;
       break;
     default:
-      gzthrow(
-          "Specific value of enum type "
-          "gz_sensor_msgs::NavSatFix::PositionCovarianceType is not yet "
-          "supported.");
+      gzthrow("Specific value of enum type "
+              "gz_sensor_msgs::NavSatFix::PositionCovarianceType is not yet "
+              "supported.");
   }
 
   // Position covariance should have 9 elements, and both the Gazebo and ROS
@@ -642,15 +760,18 @@ void GazeboRosInterfacePlugin::GzNavSatFixCallback(
             "elements.");
   for (int i = 0; i < gz_nav_sat_fix_msg->position_covariance_size(); i++) {
     ros_nav_sat_fix_msg_.position_covariance[i] =
-        gz_nav_sat_fix_msg->position_covariance(i);
+      gz_nav_sat_fix_msg->position_covariance(i);
   }
 
   // Publish to ROS.
   ros_publisher.publish(ros_nav_sat_fix_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzOdometryMsgCallback(
-    GzOdometryMsgPtr& gz_odometry_msg, ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzOdometryMsgCallback(
+  GzOdometryMsgPtr& gz_odometry_msg,
+  ros::Publisher ros_publisher)
+{
   // We need to convert from a Gazebo message to a ROS message, and then forward
   // the Odometry message to ROS.
 
@@ -665,54 +786,56 @@ void GazeboRosInterfacePlugin::GzOdometryMsgCallback(
   // ===================== POSE ================= //
   // ============================================ //
   ros_odometry_msg_.pose.pose.position.x =
-      gz_odometry_msg->pose().pose().position().x();
+    gz_odometry_msg->pose().pose().position().x();
   ros_odometry_msg_.pose.pose.position.y =
-      gz_odometry_msg->pose().pose().position().y();
+    gz_odometry_msg->pose().pose().position().y();
   ros_odometry_msg_.pose.pose.position.z =
-      gz_odometry_msg->pose().pose().position().z();
+    gz_odometry_msg->pose().pose().position().z();
 
   ros_odometry_msg_.pose.pose.orientation.w =
-      gz_odometry_msg->pose().pose().orientation().w();
+    gz_odometry_msg->pose().pose().orientation().w();
   ros_odometry_msg_.pose.pose.orientation.x =
-      gz_odometry_msg->pose().pose().orientation().x();
+    gz_odometry_msg->pose().pose().orientation().x();
   ros_odometry_msg_.pose.pose.orientation.y =
-      gz_odometry_msg->pose().pose().orientation().y();
+    gz_odometry_msg->pose().pose().orientation().y();
   ros_odometry_msg_.pose.pose.orientation.z =
-      gz_odometry_msg->pose().pose().orientation().z();
+    gz_odometry_msg->pose().pose().orientation().z();
 
   for (int i = 0; i < gz_odometry_msg->pose().covariance_size(); i++) {
     ros_odometry_msg_.pose.covariance[i] =
-        gz_odometry_msg->pose().covariance(i);
+      gz_odometry_msg->pose().covariance(i);
   }
 
   // ============================================ //
   // ===================== TWIST ================ //
   // ============================================ //
   ros_odometry_msg_.twist.twist.linear.x =
-      gz_odometry_msg->twist().twist().linear().x();
+    gz_odometry_msg->twist().twist().linear().x();
   ros_odometry_msg_.twist.twist.linear.y =
-      gz_odometry_msg->twist().twist().linear().y();
+    gz_odometry_msg->twist().twist().linear().y();
   ros_odometry_msg_.twist.twist.linear.z =
-      gz_odometry_msg->twist().twist().linear().z();
+    gz_odometry_msg->twist().twist().linear().z();
 
   ros_odometry_msg_.twist.twist.angular.x =
-      gz_odometry_msg->twist().twist().angular().x();
+    gz_odometry_msg->twist().twist().angular().x();
   ros_odometry_msg_.twist.twist.angular.y =
-      gz_odometry_msg->twist().twist().angular().y();
+    gz_odometry_msg->twist().twist().angular().y();
   ros_odometry_msg_.twist.twist.angular.z =
-      gz_odometry_msg->twist().twist().angular().z();
+    gz_odometry_msg->twist().twist().angular().z();
 
   for (int i = 0; i < gz_odometry_msg->twist().covariance_size(); i++) {
     ros_odometry_msg_.twist.covariance[i] =
-        gz_odometry_msg->twist().covariance(i);
+      gz_odometry_msg->twist().covariance(i);
   }
 
   // Publish to ROS framework.
   ros_publisher.publish(ros_odometry_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzPoseMsgCallback(GzPoseMsgPtr& gz_pose_msg,
-                                                 ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzPoseMsgCallback(GzPoseMsgPtr& gz_pose_msg,
+                                            ros::Publisher ros_publisher)
+{
   ros_pose_msg_.position.x = gz_pose_msg->position().x();
   ros_pose_msg_.position.y = gz_pose_msg->position().y();
   ros_pose_msg_.position.z = gz_pose_msg->position().z();
@@ -725,9 +848,11 @@ void GazeboRosInterfacePlugin::GzPoseMsgCallback(GzPoseMsgPtr& gz_pose_msg,
   ros_publisher.publish(ros_pose_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzPoseWithCovarianceStampedMsgCallback(
-    GzPoseWithCovarianceStampedMsgPtr& gz_pose_with_covariance_stamped_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzPoseWithCovarianceStampedMsgCallback(
+  GzPoseWithCovarianceStampedMsgPtr& gz_pose_with_covariance_stamped_msg,
+  ros::Publisher ros_publisher)
+{
   // ============================================ //
   // =================== HEADER ================= //
   // ============================================ //
@@ -738,46 +863,46 @@ void GazeboRosInterfacePlugin::GzPoseWithCovarianceStampedMsgCallback(
   // === POSE (both position and orientation) === //
   // ============================================ //
   ros_pose_with_covariance_stamped_msg_.pose.pose.position.x =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .position()
-          .x();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .position()
+      .x();
   ros_pose_with_covariance_stamped_msg_.pose.pose.position.y =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .position()
-          .y();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .position()
+      .y();
   ros_pose_with_covariance_stamped_msg_.pose.pose.position.z =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .position()
-          .z();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .position()
+      .z();
 
   ros_pose_with_covariance_stamped_msg_.pose.pose.orientation.w =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .orientation()
-          .w();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .orientation()
+      .w();
   ros_pose_with_covariance_stamped_msg_.pose.pose.orientation.x =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .orientation()
-          .x();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .orientation()
+      .x();
   ros_pose_with_covariance_stamped_msg_.pose.pose.orientation.y =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .orientation()
-          .y();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .orientation()
+      .y();
   ros_pose_with_covariance_stamped_msg_.pose.pose.orientation.z =
-      gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-          .pose()
-          .orientation()
-          .z();
+    gz_pose_with_covariance_stamped_msg->pose_with_covariance()
+      .pose()
+      .orientation()
+      .z();
 
   // Covariance should have 36 elements, and both the Gazebo and ROS
   // arrays should be the same size!
   GZ_ASSERT(gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-                    .covariance_size() == 36,
+                .covariance_size() == 36,
             "The Gazebo PoseWithCovarianceStamped message does not have 9 "
             "position covariance elements.");
   GZ_ASSERT(ros_pose_with_covariance_stamped_msg_.pose.covariance.size() == 36,
@@ -785,19 +910,20 @@ void GazeboRosInterfacePlugin::GzPoseWithCovarianceStampedMsgCallback(
             "position covariance elements.");
   for (int i = 0;
        i < gz_pose_with_covariance_stamped_msg->pose_with_covariance()
-               .covariance_size();
+             .covariance_size();
        i++) {
     ros_pose_with_covariance_stamped_msg_.pose.covariance[i] =
-        gz_pose_with_covariance_stamped_msg->pose_with_covariance().covariance(
-            i);
+      gz_pose_with_covariance_stamped_msg->pose_with_covariance().covariance(i);
   }
 
   ros_publisher.publish(ros_pose_with_covariance_stamped_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzTransformStampedMsgCallback(
-    GzTransformStampedMsgPtr& gz_transform_stamped_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzTransformStampedMsgCallback(
+  GzTransformStampedMsgPtr& gz_transform_stamped_msg,
+  ros::Publisher ros_publisher)
+{
   // ============================================ //
   // =================== HEADER ================= //
   // ============================================ //
@@ -808,29 +934,32 @@ void GazeboRosInterfacePlugin::GzTransformStampedMsgCallback(
   // =========== TRANSFORM, TRANSLATION ========= //
   // ============================================ //
   ros_transform_stamped_msg_.transform.translation.x =
-      gz_transform_stamped_msg->transform().translation().x();
+    gz_transform_stamped_msg->transform().translation().x();
   ros_transform_stamped_msg_.transform.translation.y =
-      gz_transform_stamped_msg->transform().translation().y();
+    gz_transform_stamped_msg->transform().translation().y();
   ros_transform_stamped_msg_.transform.translation.z =
-      gz_transform_stamped_msg->transform().translation().z();
+    gz_transform_stamped_msg->transform().translation().z();
 
   // ============================================ //
   // ============ TRANSFORM, ROTATION =========== //
   // ============================================ //
   ros_transform_stamped_msg_.transform.rotation.w =
-      gz_transform_stamped_msg->transform().rotation().w();
+    gz_transform_stamped_msg->transform().rotation().w();
   ros_transform_stamped_msg_.transform.rotation.x =
-      gz_transform_stamped_msg->transform().rotation().x();
+    gz_transform_stamped_msg->transform().rotation().x();
   ros_transform_stamped_msg_.transform.rotation.y =
-      gz_transform_stamped_msg->transform().rotation().y();
+    gz_transform_stamped_msg->transform().rotation().y();
   ros_transform_stamped_msg_.transform.rotation.z =
-      gz_transform_stamped_msg->transform().rotation().z();
+    gz_transform_stamped_msg->transform().rotation().z();
 
   ros_publisher.publish(ros_transform_stamped_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzTwistStampedMsgCallback(
-    GzTwistStampedMsgPtr& gz_twist_stamped_msg, ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzTwistStampedMsgCallback(
+  GzTwistStampedMsgPtr& gz_twist_stamped_msg,
+  ros::Publisher ros_publisher)
+{
   // ============================================ //
   // =================== HEADER ================= //
   // ============================================ //
@@ -842,25 +971,27 @@ void GazeboRosInterfacePlugin::GzTwistStampedMsgCallback(
   // ============================================ //
 
   ros_twist_stamped_msg_.twist.linear.x =
-      gz_twist_stamped_msg->twist().linear().x();
+    gz_twist_stamped_msg->twist().linear().x();
   ros_twist_stamped_msg_.twist.linear.y =
-      gz_twist_stamped_msg->twist().linear().y();
+    gz_twist_stamped_msg->twist().linear().y();
   ros_twist_stamped_msg_.twist.linear.z =
-      gz_twist_stamped_msg->twist().linear().z();
+    gz_twist_stamped_msg->twist().linear().z();
 
   ros_twist_stamped_msg_.twist.angular.x =
-      gz_twist_stamped_msg->twist().angular().x();
+    gz_twist_stamped_msg->twist().angular().x();
   ros_twist_stamped_msg_.twist.angular.y =
-      gz_twist_stamped_msg->twist().angular().y();
+    gz_twist_stamped_msg->twist().angular().y();
   ros_twist_stamped_msg_.twist.angular.z =
-      gz_twist_stamped_msg->twist().angular().z();
+    gz_twist_stamped_msg->twist().angular().z();
 
   ros_publisher.publish(ros_twist_stamped_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback(
-    GzVector3dStampedMsgPtr& gz_vector_3d_stamped_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback(
+  GzVector3dStampedMsgPtr& gz_vector_3d_stamped_msg,
+  ros::Publisher ros_publisher)
+{
   // ============================================ //
   // =================== HEADER ================= //
   // ============================================ //
@@ -878,9 +1009,11 @@ void GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback(
   ros_publisher.publish(ros_position_stamped_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzWindSpeedMsgCallback(
-    GzWindSpeedMsgPtr& gz_wind_speed_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzWindSpeedMsgCallback(
+  GzWindSpeedMsgPtr& gz_wind_speed_msg,
+  ros::Publisher ros_publisher)
+{
   // ============================================ //
   // =================== HEADER ================= //
   // ============================================ //
@@ -890,18 +1023,17 @@ void GazeboRosInterfacePlugin::GzWindSpeedMsgCallback(
   // ============================================ //
   // ================== VELOCITY ================ //
   // ============================================ //
-  ros_wind_speed_msg_.velocity.x =
-      gz_wind_speed_msg->velocity().x();
-  ros_wind_speed_msg_.velocity.y =
-      gz_wind_speed_msg->velocity().y();
-  ros_wind_speed_msg_.velocity.z =
-      gz_wind_speed_msg->velocity().z();
+  ros_wind_speed_msg_.velocity.x = gz_wind_speed_msg->velocity().x();
+  ros_wind_speed_msg_.velocity.y = gz_wind_speed_msg->velocity().y();
+  ros_wind_speed_msg_.velocity.z = gz_wind_speed_msg->velocity().z();
   ros_publisher.publish(ros_wind_speed_msg_);
 }
 
-void GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback(
-    GzWrenchStampedMsgPtr& gz_wrench_stamped_msg,
-    ros::Publisher ros_publisher) {
+void
+GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback(
+  GzWrenchStampedMsgPtr& gz_wrench_stamped_msg,
+  ros::Publisher ros_publisher)
+{
   // ============================================ //
   // =================== HEADER ================= //
   // ============================================ //
@@ -912,21 +1044,21 @@ void GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback(
   // =================== FORCE ================== //
   // ============================================ //
   ros_wrench_stamped_msg_.wrench.force.x =
-      gz_wrench_stamped_msg->wrench().force().x();
+    gz_wrench_stamped_msg->wrench().force().x();
   ros_wrench_stamped_msg_.wrench.force.y =
-      gz_wrench_stamped_msg->wrench().force().y();
+    gz_wrench_stamped_msg->wrench().force().y();
   ros_wrench_stamped_msg_.wrench.force.z =
-      gz_wrench_stamped_msg->wrench().force().z();
+    gz_wrench_stamped_msg->wrench().force().z();
 
   // ============================================ //
   // ==================== TORQUE ================ //
   // ============================================ //
   ros_wrench_stamped_msg_.wrench.torque.x =
-      gz_wrench_stamped_msg->wrench().torque().x();
+    gz_wrench_stamped_msg->wrench().torque().x();
   ros_wrench_stamped_msg_.wrench.torque.y =
-      gz_wrench_stamped_msg->wrench().torque().y();
+    gz_wrench_stamped_msg->wrench().torque().y();
   ros_wrench_stamped_msg_.wrench.torque.z =
-      gz_wrench_stamped_msg->wrench().torque().z();
+    gz_wrench_stamped_msg->wrench().torque().z();
 
   ros_publisher.publish(ros_wrench_stamped_msg_);
 }
@@ -935,9 +1067,11 @@ void GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback(
 //================ ROS -> GAZEBO MSG CALLBACKS/CONVERTERS ===================//
 //===========================================================================//
 
-void GazeboRosInterfacePlugin::RosActuatorsMsgCallback(
-    const mav_msgs::ActuatorsConstPtr& ros_actuators_msg_ptr,
-    gazebo::transport::PublisherPtr gz_publisher_ptr) {
+void
+GazeboRosInterfacePlugin::RosActuatorsMsgCallback(
+  const mav_msgs::ActuatorsConstPtr& ros_actuators_msg_ptr,
+  gazebo::transport::PublisherPtr gz_publisher_ptr)
+{
   // Convert ROS message to Gazebo message
 
   gz_sensor_msgs::Actuators gz_actuators_msg;
@@ -946,44 +1080,46 @@ void GazeboRosInterfacePlugin::RosActuatorsMsgCallback(
                        gz_actuators_msg.mutable_header());
 
   for (int i = 0; i < ros_actuators_msg_ptr->angles.size(); i++) {
-    gz_actuators_msg.add_angles(
-        ros_actuators_msg_ptr->angles[i]);
+    gz_actuators_msg.add_angles(ros_actuators_msg_ptr->angles[i]);
   }
 
   for (int i = 0; i < ros_actuators_msg_ptr->angular_velocities.size(); i++) {
     gz_actuators_msg.add_angular_velocities(
-        ros_actuators_msg_ptr->angular_velocities[i]);
+      ros_actuators_msg_ptr->angular_velocities[i]);
   }
 
   for (int i = 0; i < ros_actuators_msg_ptr->normalized.size(); i++) {
-    gz_actuators_msg.add_normalized(
-        ros_actuators_msg_ptr->normalized[i]);
+    gz_actuators_msg.add_normalized(ros_actuators_msg_ptr->normalized[i]);
   }
 
   // Publish to Gazebo
   gz_publisher_ptr->Publish(gz_actuators_msg);
 }
 
-void GazeboRosInterfacePlugin::RosCommandMotorSpeedMsgCallback(
-    const mav_msgs::ActuatorsConstPtr& ros_actuators_msg_ptr,
-    gazebo::transport::PublisherPtr gz_publisher_ptr) {
+void
+GazeboRosInterfacePlugin::RosCommandMotorSpeedMsgCallback(
+  const mav_msgs::ActuatorsConstPtr& ros_actuators_msg_ptr,
+  gazebo::transport::PublisherPtr gz_publisher_ptr)
+{
   // Convert ROS message to Gazebo message
 
   gz_mav_msgs::CommandMotorSpeed gz_command_motor_speed_msg;
 
   for (int i = 0; i < ros_actuators_msg_ptr->angular_velocities.size(); i++) {
     gz_command_motor_speed_msg.add_motor_speed(
-        ros_actuators_msg_ptr->angular_velocities[i]);
+      ros_actuators_msg_ptr->angular_velocities[i]);
   }
 
   // Publish to Gazebo
   gz_publisher_ptr->Publish(gz_command_motor_speed_msg);
 }
 
-void GazeboRosInterfacePlugin::RosRollPitchYawrateThrustMsgCallback(
-    const mav_msgs::RollPitchYawrateThrustConstPtr&
-        ros_roll_pitch_yawrate_thrust_msg_ptr,
-    gazebo::transport::PublisherPtr gz_publisher_ptr) {
+void
+GazeboRosInterfacePlugin::RosRollPitchYawrateThrustMsgCallback(
+  const mav_msgs::RollPitchYawrateThrustConstPtr&
+    ros_roll_pitch_yawrate_thrust_msg_ptr,
+  gazebo::transport::PublisherPtr gz_publisher_ptr)
+{
   // Convert ROS message to Gazebo message
 
   gz_mav_msgs::RollPitchYawrateThrust gz_roll_pitch_yawrate_thrust_msg;
@@ -992,26 +1128,28 @@ void GazeboRosInterfacePlugin::RosRollPitchYawrateThrustMsgCallback(
                        gz_roll_pitch_yawrate_thrust_msg.mutable_header());
 
   gz_roll_pitch_yawrate_thrust_msg.set_roll(
-      ros_roll_pitch_yawrate_thrust_msg_ptr->roll);
+    ros_roll_pitch_yawrate_thrust_msg_ptr->roll);
   gz_roll_pitch_yawrate_thrust_msg.set_pitch(
-      ros_roll_pitch_yawrate_thrust_msg_ptr->pitch);
+    ros_roll_pitch_yawrate_thrust_msg_ptr->pitch);
   gz_roll_pitch_yawrate_thrust_msg.set_yaw_rate(
-      ros_roll_pitch_yawrate_thrust_msg_ptr->yaw_rate);
+    ros_roll_pitch_yawrate_thrust_msg_ptr->yaw_rate);
 
   gz_roll_pitch_yawrate_thrust_msg.mutable_thrust()->set_x(
-      ros_roll_pitch_yawrate_thrust_msg_ptr->thrust.x);
+    ros_roll_pitch_yawrate_thrust_msg_ptr->thrust.x);
   gz_roll_pitch_yawrate_thrust_msg.mutable_thrust()->set_y(
-      ros_roll_pitch_yawrate_thrust_msg_ptr->thrust.y);
+    ros_roll_pitch_yawrate_thrust_msg_ptr->thrust.y);
   gz_roll_pitch_yawrate_thrust_msg.mutable_thrust()->set_z(
-      ros_roll_pitch_yawrate_thrust_msg_ptr->thrust.z);
+    ros_roll_pitch_yawrate_thrust_msg_ptr->thrust.z);
 
   // Publish to Gazebo
   gz_publisher_ptr->Publish(gz_roll_pitch_yawrate_thrust_msg);
 }
 
-void GazeboRosInterfacePlugin::RosWindSpeedMsgCallback(
-    const crazyflie_gazebo::WindSpeedConstPtr& ros_wind_speed_msg_ptr,
-    gazebo::transport::PublisherPtr gz_publisher_ptr) {
+void
+GazeboRosInterfacePlugin::RosWindSpeedMsgCallback(
+  const crazyflie_gazebo::WindSpeedConstPtr& ros_wind_speed_msg_ptr,
+  gazebo::transport::PublisherPtr gz_publisher_ptr)
+{
   // Convert ROS message to Gazebo message
 
   gz_mav_msgs::WindSpeed gz_wind_speed_msg;
@@ -1020,18 +1158,20 @@ void GazeboRosInterfacePlugin::RosWindSpeedMsgCallback(
                        gz_wind_speed_msg.mutable_header());
 
   gz_wind_speed_msg.mutable_velocity()->set_x(
-      ros_wind_speed_msg_ptr->velocity.x);
+    ros_wind_speed_msg_ptr->velocity.x);
   gz_wind_speed_msg.mutable_velocity()->set_y(
-      ros_wind_speed_msg_ptr->velocity.y);
+    ros_wind_speed_msg_ptr->velocity.y);
   gz_wind_speed_msg.mutable_velocity()->set_z(
-      ros_wind_speed_msg_ptr->velocity.z);
+    ros_wind_speed_msg_ptr->velocity.z);
 
   // Publish to Gazebo
   gz_publisher_ptr->Publish(gz_wind_speed_msg);
 }
 
-void GazeboRosInterfacePlugin::GzBroadcastTransformMsgCallback(
-    GzTransformStampedWithFrameIdsMsgPtr& broadcast_transform_msg) {
+void
+GazeboRosInterfacePlugin::GzBroadcastTransformMsgCallback(
+  GzTransformStampedWithFrameIdsMsgPtr& broadcast_transform_msg)
+{
   ros::Time stamp;
   stamp.sec = broadcast_transform_msg->header().stamp().sec();
   stamp.nsec = broadcast_transform_msg->header().stamp().nsec();
@@ -1046,11 +1186,13 @@ void GazeboRosInterfacePlugin::GzBroadcastTransformMsgCallback(
                    broadcast_transform_msg->transform().translation().z());
 
   tf_ = tf::Transform(tf_q_W_L, tf_p);
-  transform_broadcaster_.sendTransform(tf::StampedTransform(
-      tf_, stamp, broadcast_transform_msg->parent_frame_id(),
-      broadcast_transform_msg->child_frame_id()));
+  transform_broadcaster_.sendTransform(
+    tf::StampedTransform(tf_,
+                         stamp,
+                         broadcast_transform_msg->parent_frame_id(),
+                         broadcast_transform_msg->child_frame_id()));
 }
 
 GZ_REGISTER_WORLD_PLUGIN(GazeboRosInterfacePlugin);
 
-}  // namespace gazebo
+} // namespace gazebo

--- a/crazyflie_gazebo/src/gazebo_wind_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_wind_plugin.cpp
@@ -73,11 +73,6 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   if (_sdf->HasElement("xyzOffset"))
   {
     xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<V3>();
-//   #if GAZEBO_9
-//     xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<ignition::math::Vector3d>();
-// #else
-//     xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<math::Vector3>();
-// #endif
   }
   else
   {
@@ -98,15 +93,7 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
                       wind_speed_variance_);
   getSdfParam<V3>(_sdf, "windDirection", wind_direction_,
                       wind_direction_);
-//                       #if GAZEBO_9
 
-//   getSdfParam<ignition::math::Vector3d>(_sdf, "windDirection", wind_direction_,
-//                       wind_direction_);
-// #else
-//   getSdfParam<math::Vector3>(_sdf, "windDirection", wind_direction_,
-//                       wind_direction_);
-
-// #endif
   // Check if a custom static wind field should be used.
   getSdfParam<bool>(_sdf, "useCustomStaticWindField", use_custom_static_wind_field_,
                       use_custom_static_wind_field_);
@@ -127,13 +114,6 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
                         wind_gust_force_variance_);
     getSdfParam<V3>(_sdf, "windGustDirection", wind_gust_direction_,
                         wind_gust_direction_);
-//                         #if GAZEBO_9
-//     getSdfParam<ignition::math::Vector3d>(_sdf, "windGustDirection", wind_gust_direction_,
-//                         wind_gust_direction_);
-// #else
-//     getSdfParam<math::Vector3>(_sdf, "windGustDirection", wind_gust_direction_,
-//                         wind_gust_direction_);
-// #endif
 
     wind_direction_.Normalize();
     wind_gust_direction_.Normalize();
@@ -177,31 +157,17 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
   common::Time now = world_->GetSimTime();
 #endif
   
-//   #if GAZEBO_9
-//   ignition::math::Vector3d wind_velocity(0.0, 0.0, 0.0);
-// #else
-//   math::Vector3 wind_velocity(0.0, 0.0, 0.0);
-// #endif
   V3 wind_velocity(0.0, 0.0, 0.0);
 
   // Choose user-specified method for calculating wind velocity.
   if (!use_custom_static_wind_field_) {
     // Calculate the wind force.
     double wind_strength = wind_force_mean_;
-//     #if GAZEBO_9
-//     ignition::math::Vector3d wind = wind_strength * wind_direction_;
-// #else
-//     math::Vector3 wind = wind_strength * wind_direction_;
-// #endif
+
     V3 wind = wind_strength * wind_direction_;
     // Apply a force from the constant wind to the link.
     link_->AddForceAtRelativePosition(wind, xyz_offset_);
 
-// #if GAZEBO_9
-//     ignition::math::Vector3d wind_gust(0.0, 0.0, 0.0);
-// #else
-//     math::Vector3 wind_gust(0.0, 0.0, 0.0);
-// #endif
     V3 wind_gust(0.0, 0.0, 0.0);
     // Calculate the wind gust force.
     if (now >= wind_gust_start_ && now < wind_gust_end_) {
@@ -245,7 +211,7 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
     #if GAZEBO_9
     V3 link_position = link_->WorldPose().Pos();
 #else
-    math::Vector3 link_position = link_->GetWorldPose().pos;
+    V3 link_position = link_->GetWorldPose().pos;
 #endif
 
     // Calculate the x, y index of the grid points with x, y-coordinate 
@@ -332,11 +298,6 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
       // Extract the wind velocities corresponding to each vertex.
       V3 wind_at_vertices[n_vertices];
-//       #if GAZEBO_9
-//       ignition::math::Vector3d wind_at_vertices[n_vertices];
-// #else
-//       math::Vector3 wind_at_vertices[n_vertices];
-// #endif
       for (std::size_t i = 0u; i < n_vertices; ++i) {
         #if GAZEBO_9
         double& wav_x = wind_at_vertices[i].X();

--- a/crazyflie_gazebo/src/gazebo_wind_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_wind_plugin.cpp
@@ -22,7 +22,7 @@
 #if GAZEBO_9
 #include <ignition/math/Vector3.hh>
 #else
-#include <gazebo/Math/Vector3.hh>
+#include <gazebo/math/gzmath.hh>
 #endif
 #include "gazebo_wind_plugin.h"
 

--- a/crazyflie_gazebo/src/gazebo_wind_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_wind_plugin.cpp
@@ -18,18 +18,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#include "_version.h"
+#if GAZEBO_9
+#include <ignition/math/Vector3.hh>
+#else
+#include <gazebo/Math/Vector3.hh>
+#endif
 #include "gazebo_wind_plugin.h"
 
 #include <fstream>
 #include <math.h>
+    
 
 #include "ConnectGazeboToRosTopic.pb.h"
 
 namespace gazebo {
 
+
 GazeboWindPlugin::~GazeboWindPlugin() {
+    #if GAZEBO_9
+    #else
   event::Events::DisconnectWorldUpdateBegin(update_connection_);
+    #endif
+    
 }
 
 void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -60,9 +71,19 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   node_handle_->Init();
 
   if (_sdf->HasElement("xyzOffset"))
-    xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<math::Vector3>();
+  {
+    xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<V3>();
+//   #if GAZEBO_9
+//     xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<ignition::math::Vector3d>();
+// #else
+//     xyz_offset_ = _sdf->GetElement("xyzOffset")->Get<math::Vector3>();
+// #endif
+  }
   else
+  {
     gzerr << "[gazebo_wind_plugin] Please specify a xyzOffset.\n";
+
+  }
 
   getSdfParam<std::string>(_sdf, "windForcePubTopic", wind_force_pub_topic_,
                            wind_force_pub_topic_);
@@ -75,8 +96,17 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
                       wind_speed_mean_);
   getSdfParam<double>(_sdf, "windSpeedVariance", wind_speed_variance_,
                       wind_speed_variance_);
-  getSdfParam<math::Vector3>(_sdf, "windDirection", wind_direction_,
+  getSdfParam<V3>(_sdf, "windDirection", wind_direction_,
                       wind_direction_);
+//                       #if GAZEBO_9
+
+//   getSdfParam<ignition::math::Vector3d>(_sdf, "windDirection", wind_direction_,
+//                       wind_direction_);
+// #else
+//   getSdfParam<math::Vector3>(_sdf, "windDirection", wind_direction_,
+//                       wind_direction_);
+
+// #endif
   // Check if a custom static wind field should be used.
   getSdfParam<bool>(_sdf, "useCustomStaticWindField", use_custom_static_wind_field_,
                       use_custom_static_wind_field_);
@@ -95,8 +125,15 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
                         wind_gust_force_mean_);
     getSdfParam<double>(_sdf, "windGustForceVariance", wind_gust_force_variance_,
                         wind_gust_force_variance_);
-    getSdfParam<math::Vector3>(_sdf, "windGustDirection", wind_gust_direction_,
+    getSdfParam<V3>(_sdf, "windGustDirection", wind_gust_direction_,
                         wind_gust_direction_);
+//                         #if GAZEBO_9
+//     getSdfParam<ignition::math::Vector3d>(_sdf, "windGustDirection", wind_gust_direction_,
+//                         wind_gust_direction_);
+// #else
+//     getSdfParam<math::Vector3>(_sdf, "windGustDirection", wind_gust_direction_,
+//                         wind_gust_direction_);
+// #endif
 
     wind_direction_.Normalize();
     wind_gust_direction_.Normalize();
@@ -134,19 +171,38 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
   }
 
   // Get the current simulation time.
+  #if GAZEBO_9
+  common::Time now = world_->SimTime();
+#else
   common::Time now = world_->GetSimTime();
+#endif
   
-  math::Vector3 wind_velocity(0.0, 0.0, 0.0);
+//   #if GAZEBO_9
+//   ignition::math::Vector3d wind_velocity(0.0, 0.0, 0.0);
+// #else
+//   math::Vector3 wind_velocity(0.0, 0.0, 0.0);
+// #endif
+  V3 wind_velocity(0.0, 0.0, 0.0);
 
   // Choose user-specified method for calculating wind velocity.
   if (!use_custom_static_wind_field_) {
     // Calculate the wind force.
     double wind_strength = wind_force_mean_;
-    math::Vector3 wind = wind_strength * wind_direction_;
+//     #if GAZEBO_9
+//     ignition::math::Vector3d wind = wind_strength * wind_direction_;
+// #else
+//     math::Vector3 wind = wind_strength * wind_direction_;
+// #endif
+    V3 wind = wind_strength * wind_direction_;
     // Apply a force from the constant wind to the link.
     link_->AddForceAtRelativePosition(wind, xyz_offset_);
 
-    math::Vector3 wind_gust(0.0, 0.0, 0.0);
+// #if GAZEBO_9
+//     ignition::math::Vector3d wind_gust(0.0, 0.0, 0.0);
+// #else
+//     math::Vector3 wind_gust(0.0, 0.0, 0.0);
+// #endif
+    V3 wind_gust(0.0, 0.0, 0.0);
     // Calculate the wind gust force.
     if (now >= wind_gust_start_ && now < wind_gust_end_) {
       double wind_gust_strength = wind_gust_force_mean_;
@@ -159,12 +215,21 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
     wrench_stamped_msg_.mutable_header()->mutable_stamp()->set_sec(now.sec);
     wrench_stamped_msg_.mutable_header()->mutable_stamp()->set_nsec(now.nsec);
 
+#if GAZEBO_9
+    wrench_stamped_msg_.mutable_wrench()->mutable_force()->set_x(wind.X() +
+                                                                 wind_gust.X());
+    wrench_stamped_msg_.mutable_wrench()->mutable_force()->set_y(wind.Y() +
+                                                                 wind_gust.Y());
+    wrench_stamped_msg_.mutable_wrench()->mutable_force()->set_z(wind.Z() +
+                                                                 wind_gust.Z());
+#else
     wrench_stamped_msg_.mutable_wrench()->mutable_force()->set_x(wind.x +
                                                                  wind_gust.x);
     wrench_stamped_msg_.mutable_wrench()->mutable_force()->set_y(wind.y +
                                                                  wind_gust.y);
     wrench_stamped_msg_.mutable_wrench()->mutable_force()->set_z(wind.z +
                                                                  wind_gust.z);
+#endif
 
     // No torque due to wind, set x,y and z to 0.
     wrench_stamped_msg_.mutable_wrench()->mutable_torque()->set_x(0);
@@ -177,12 +242,21 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
     wind_velocity = wind_speed_mean_ * wind_direction_;
   } else {
     // Get the current position of the aircraft in world coordinates.
+    #if GAZEBO_9
+    V3 link_position = link_->WorldPose().Pos();
+#else
     math::Vector3 link_position = link_->GetWorldPose().pos;
+#endif
 
     // Calculate the x, y index of the grid points with x, y-coordinate 
     // just smaller than or equal to aircraft x, y position.
+    #if GAZEBO_9
+    std::size_t x_inf = floor((link_position.X() - min_x_) / res_x_);
+    std::size_t y_inf = floor((link_position.Y() - min_y_) / res_y_);
+#else
     std::size_t x_inf = floor((link_position.x - min_x_) / res_x_);
     std::size_t y_inf = floor((link_position.y - min_y_) / res_y_);
+#endif
 
     // In case aircraft is on one of the boundary surfaces at max_x or max_y,
     // decrease x_inf, y_inf by one to have x_sup, y_sup on max_x, max_y.
@@ -209,8 +283,13 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
     constexpr unsigned int n_columns = 4;
     float vertical_factors_columns[n_columns];
     for (std::size_t i = 0u; i < n_columns; ++i) {
+      #if GAZEBO_9
+      double link_pos_z = link_position.Z();
+#else
+      double link_pos_z = link_position.z;
+#endif
       vertical_factors_columns[i] = (
-        link_position.z - bottom_z_[idx_x[2u * i] + idx_y[2u * i] * n_x_]) /
+        link_pos_z - bottom_z_[idx_x[2u * i] + idx_y[2u * i] * n_x_]) /
         (top_z_[idx_x[2u * i] + idx_y[2u * i] * n_x_] - bottom_z_[idx_x[2u * i] + idx_y[2u * i] * n_x_]);
     }
     
@@ -252,11 +331,25 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
       }
 
       // Extract the wind velocities corresponding to each vertex.
-      math::Vector3 wind_at_vertices[n_vertices];
+      V3 wind_at_vertices[n_vertices];
+//       #if GAZEBO_9
+//       ignition::math::Vector3d wind_at_vertices[n_vertices];
+// #else
+//       math::Vector3 wind_at_vertices[n_vertices];
+// #endif
       for (std::size_t i = 0u; i < n_vertices; ++i) {
-        wind_at_vertices[i].x = u_[idx_x[i] + idx_y[i] * n_x_ + idx_z[i] * n_x_ * n_y_];
-        wind_at_vertices[i].y = v_[idx_x[i] + idx_y[i] * n_x_ + idx_z[i] * n_x_ * n_y_];
-        wind_at_vertices[i].z = w_[idx_x[i] + idx_y[i] * n_x_ + idx_z[i] * n_x_ * n_y_];
+        #if GAZEBO_9
+        double& wav_x = wind_at_vertices[i].X();
+        double& wav_y = wind_at_vertices[i].Y();
+        double& wav_z = wind_at_vertices[i].Z();
+#else
+        double& wav_x = wind_at_vertices[i].x;
+        double& wav_y = wind_at_vertices[i].y;
+        double& wav_z = wind_at_vertices[i].z;
+#endif
+        wav_x = u_[idx_x[i] + idx_y[i] * n_x_ + idx_z[i] * n_x_ * n_y_];
+        wav_y = v_[idx_x[i] + idx_y[i] * n_x_ + idx_z[i] * n_x_ * n_y_];
+        wav_z = w_[idx_x[i] + idx_y[i] * n_x_ + idx_z[i] * n_x_ * n_y_];
       }
 
       // Extract the relevant coordinate of every point needed for trilinear 
@@ -290,9 +383,15 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
   wind_speed_msg_.mutable_header()->mutable_stamp()->set_sec(now.sec);
   wind_speed_msg_.mutable_header()->mutable_stamp()->set_nsec(now.nsec);
 
+#if GAZEBO_9
+  wind_speed_msg_.mutable_velocity()->set_x(wind_velocity.X());
+  wind_speed_msg_.mutable_velocity()->set_y(wind_velocity.Y());
+  wind_speed_msg_.mutable_velocity()->set_z(wind_velocity.Z());
+#else
   wind_speed_msg_.mutable_velocity()->set_x(wind_velocity.x);
   wind_speed_msg_.mutable_velocity()->set_y(wind_velocity.y);
   wind_speed_msg_.mutable_velocity()->set_z(wind_velocity.z);
+#endif
 
   wind_speed_pub_->Publish(wind_speed_msg_);
 }
@@ -406,28 +505,32 @@ void GazeboWindPlugin::ReadCustomWindField(std::string& custom_wind_field_path) 
 
 }
 
-math::Vector3 GazeboWindPlugin::LinearInterpolation(
-  double position, math::Vector3* values, double* points) const {
-  math::Vector3 value = values[0] + (values[1] - values[0]) /
+GazeboWindPlugin::V3 GazeboWindPlugin::LinearInterpolation(
+  double position, V3* values, double* points) const {
+  V3 value = values[0] + (values[1] - values[0]) /
                         (points[1] - points[0]) * (position - points[0]);
   return value;
 }
 
-math::Vector3 GazeboWindPlugin::BilinearInterpolation(
-  double* position, math::Vector3* values, double* points) const {
-  math::Vector3 intermediate_values[2] = { LinearInterpolation(
+GazeboWindPlugin::V3 GazeboWindPlugin::BilinearInterpolation(
+  double* position, V3* values, double* points) const {
+  V3 intermediate_values[2] = { LinearInterpolation(
                                              position[0], &(values[0]), &(points[0])),
                                            LinearInterpolation(
                                              position[0], &(values[2]), &(points[2])) };
-  math::Vector3 value = LinearInterpolation(
+  V3 value = LinearInterpolation(
                           position[1], intermediate_values, &(points[4]));
   return value;
 }
 
-math::Vector3 GazeboWindPlugin::TrilinearInterpolation(
-  math::Vector3 link_position, math::Vector3* values, double* points) const {
+GazeboWindPlugin::V3 GazeboWindPlugin::TrilinearInterpolation(
+  V3 link_position, V3* values, double* points) const {
+    #if GAZEBO_9
+  double position[3] = {link_position.X(),link_position.Y(),link_position.Z()};
+#else
   double position[3] = {link_position.x,link_position.y,link_position.z};
-  math::Vector3 intermediate_values[4] = { LinearInterpolation(
+#endif
+  V3 intermediate_values[4] = { LinearInterpolation(
                                              position[2], &(values[0]), &(points[0])),
                                            LinearInterpolation(
                                              position[2], &(values[2]), &(points[2])),
@@ -435,7 +538,7 @@ math::Vector3 GazeboWindPlugin::TrilinearInterpolation(
                                              position[2], &(values[4]), &(points[4])),
                                            LinearInterpolation(
                                              position[2], &(values[6]), &(points[6])) };
-  math::Vector3 value = BilinearInterpolation(
+  V3 value = BilinearInterpolation(
     &(position[0]), intermediate_values, &(points[8]));
   return value;
 }


### PR DESCRIPTION
# Object
This PR introduces changes to make the code base compatible with both ROS Kinetic and ROS Melodic (gazebo v7 and v9). It fixes #2 

# Changes performed:
- use of `typedef` to transparently handle most of the internal work (introducing a vector type  `V3 ` and a pose type `P3`
- use of  `#if GAZEBO_9` macro in heavily version-dependent sections 
- [sorry] formatting changes

# Status
This PR was tested on ROS Melodic on basic scenarios successfully, in SITL and ghost mode