### PR TITLE
gazemo_odemetry_plugin: Use cv::IMREAD_GRAYSCALE

### DIFF
--- a/crazyflie_gazebo/src/gazebo_odometry_plugin.cpp
+++ b/crazyflie_gazebo/src/gazebo_odometry_plugin.cpp
@@ -97,7 +97,7 @@ GazeboOdometryPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   if (_sdf->HasElement("covarianceImage")) {
     std::string image_name =
       _sdf->GetElement("covarianceImage")->Get<std::string>();
-    covariance_image_ = cv::imread(image_name, CV_LOAD_IMAGE_GRAYSCALE);
+    covariance_image_ = cv::imread(image_name, cv::IMREAD_GRAYSCALE);
     if (covariance_image_.data == NULL)
       gzerr << "loading covariance image " << image_name << " failed"
             << std::endl;


### PR DESCRIPTION
This is the way with latest OpenCV:
  https://docs.opencv.org/master/d4/da8/group__imgcodecs.html

Fixes #21 